### PR TITLE
feat: add ConfigMap and Secret constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 
 ## Available constructs
 
+- `ConfigMap`
+
+  - Represents a Kubernetes ConfigMap.
+  - Supports setting a key/value from a file.
+  - Supports loading keys/values from a .env file.
+  - Supports setting binary data.
+  - Example use can be found in [WebService advanced example](./examples/advanced-web-service/README.md).
+
+- `Secret`
+
+  - Represents a Kubernetes Secret.
+  - Encodes data in base64.
+  - Supports setting a key/value from a file.
+  - Supports loading keys/values from a .env file.
+  - Supports setting string data, allowing Kubernetes API to encode on write.
+
 - `WebService`
 
   - Represents a web application exposed via an AWS Application Load Balancer.

--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -14,6 +14,7 @@ Array [
         "prunable": "true",
       },
       "name": "test-config-c819b74b-7ffghtft2m",
+      "namespace": "example-web-service",
     },
   },
   Object {
@@ -483,6 +484,7 @@ Array [
         "prunable": "true",
       },
       "name": "test-config-c819b74b-7ffghtft2m",
+      "namespace": "example-web-service",
     },
   },
   Object {
@@ -1154,6 +1156,7 @@ Array [
         "prunable": "true",
       },
       "name": "test-config-c819b74b-7ffghtft2m",
+      "namespace": "example-web-service",
     },
   },
   Object {
@@ -1623,6 +1626,7 @@ Array [
         "prunable": "true",
       },
       "name": "test-config-c819b74b-7ffghtft2m",
+      "namespace": "example-web-service",
     },
   },
   Object {
@@ -2293,6 +2297,7 @@ Array [
         "prunable": "true",
       },
       "name": "test-config-c819b74b-7ffghtft2m",
+      "namespace": "example-web-service",
     },
   },
   Object {

--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -5,6 +5,20 @@ Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
+      "ENVIRONMENT": "demo",
+      "MESSAGE": "Hello CDK8s!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-config-c819b74b-7ffghtft2m",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
       "default.conf": "map $http_upgrade $connection_upgrade {
     default \\"upgrade\\";
     \\"\\" \\"\\";
@@ -344,6 +358,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                   "value": "0",
                 },
               ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
+                },
+              ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.2",
               "imagePullPolicy": "IfNotPresent",
               "livenessProbe": Object {
@@ -450,6 +471,20 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
 
 exports[`Advanced WebService example Snapshot base stage 1`] = `
 Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "ENVIRONMENT": "demo",
+      "MESSAGE": "Hello CDK8s!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-config-c819b74b-7ffghtft2m",
+    },
+  },
   Object {
     "apiVersion": "v1",
     "data": Object {
@@ -713,6 +748,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                 Object {
                   "name": "ROLLUP_WATCH",
                   "value": "0",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
                 },
               ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",
@@ -985,6 +1027,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                 Object {
                   "name": "ROLLUP_WATCH",
                   "value": "0",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
                 },
               ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",
@@ -1096,6 +1145,20 @@ Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
+      "ENVIRONMENT": "demo",
+      "MESSAGE": "Hello CDK8s!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-config-c819b74b-7ffghtft2m",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
       "default.conf": "map $http_upgrade $connection_upgrade {
     default \\"upgrade\\";
     \\"\\" \\"\\";
@@ -1435,6 +1498,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                   "value": "0",
                 },
               ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
+                },
+              ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "livenessProbe": Object {
@@ -1541,6 +1611,20 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
 
 exports[`Advanced WebService example Snapshot full stage 1`] = `
 Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "ENVIRONMENT": "demo",
+      "MESSAGE": "Hello CDK8s!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-config-c819b74b-7ffghtft2m",
+    },
+  },
   Object {
     "apiVersion": "v1",
     "data": Object {
@@ -1803,6 +1887,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                 Object {
                   "name": "ROLLUP_WATCH",
                   "value": "0",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
                 },
               ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",
@@ -2077,6 +2168,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                   "value": "0",
                 },
               ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
+                },
+              ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "livenessProbe": Object {
@@ -2183,6 +2281,20 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
 
 exports[`Advanced WebService example Snapshot post-canary stage 1`] = `
 Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "ENVIRONMENT": "demo",
+      "MESSAGE": "Hello CDK8s!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-config-c819b74b-7ffghtft2m",
+    },
+  },
   Object {
     "apiVersion": "v1",
     "data": Object {
@@ -2522,6 +2634,13 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
                 Object {
                   "name": "ROLLUP_WATCH",
                   "value": "0",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "test-config-c819b74b-7ffghtft2m",
+                  },
                 },
               ],
               "image": "docker.io/rodolphoalves/swapi-deno:v0.2.1",

--- a/examples/advanced-web-service/chart.ts
+++ b/examples/advanced-web-service/chart.ts
@@ -1,7 +1,8 @@
 import { Construct } from "constructs";
 import { Chart, ChartProps } from "cdk8s";
-import { getCanaryStage, WebService, nginxUtil } from "../../lib";
+import { getCanaryStage, nginxUtil, ConfigMap, WebService } from "../../lib";
 import { IntOrString, KubeNamespace, Quantity } from "../../imports/k8s";
+import path from "path";
 
 export class AdvancedWebServiceChart extends Chart {
   constructor(
@@ -15,6 +16,10 @@ export class AdvancedWebServiceChart extends Chart {
     const release = process.env.RELEASE || "v0.2.1";
 
     const applicationPort = 8000;
+    const appConfigMap = new ConfigMap(this, "config", {
+      envFiles: [path.resolve(__dirname, "example.env")],
+    });
+
     const nginxPort = 80;
     const nginxConfigMap = nginxUtil.createConfigMap(this, {
       includeDefaultConfig: true,
@@ -46,6 +51,11 @@ export class AdvancedWebServiceChart extends Chart {
         {
           name: "ROLLUP_WATCH",
           value: "0",
+        },
+      ],
+      envFrom: [
+        {
+          configMapRef: { name: appConfigMap.name },
         },
       ],
       resources: {

--- a/examples/advanced-web-service/example.env
+++ b/examples/advanced-web-service/example.env
@@ -1,0 +1,2 @@
+ENVIRONMENT=demo
+MESSAGE=Hello CDK8s!

--- a/examples/advanced-web-service/main.ts
+++ b/examples/advanced-web-service/main.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { App } from "cdk8s";
 import { AdvancedWebServiceChart } from "./chart";
 

--- a/lib/data/config-map.ts
+++ b/lib/data/config-map.ts
@@ -24,8 +24,7 @@ export interface ConfigMapProps {
   readonly immutable?: boolean;
 
   /**
-   * Map of key/value pairs of configuration data e.g.
-   * 'environment variable' = 'value', 'filename' = 'contents'.
+   * Map of key/value pairs of configuration data e.g. 'env-var' = 'value', 'filename' = 'contents'.
    *
    * You can also set data using `configMap.setData()`.
    */

--- a/lib/data/config-map.ts
+++ b/lib/data/config-map.ts
@@ -1,0 +1,278 @@
+import {
+  ApiObject,
+  ApiObjectMetadata,
+  ApiObjectMetadataDefinition,
+  Lazy,
+} from "cdk8s";
+import { Construct } from "constructs";
+import { parse } from "dotenv";
+import { readFileSync } from "fs";
+import { basename } from "path";
+import { KubeConfigMap } from "../../imports/k8s";
+import { hashObject } from "./hash-util";
+
+export interface ConfigMapProps {
+  /**
+   * Metadata that all persisted resources must have, which includes all objects
+   * users must create.
+   */
+  readonly metadata?: ApiObjectMetadata;
+
+  /**
+   * Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+   */
+  readonly immutable?: boolean;
+
+  /**
+   * Map of key/value pairs of configuration data e.g.
+   * 'environment variable' = 'value', 'filename' = 'contents'.
+   *
+   * You can also set data using `configMap.setData()`.
+   */
+  readonly data?: { [key: string]: string };
+
+  /**
+   * Map of key/value pairs of binary data e.g. 'filename' = 'contents'.
+   *
+   * You can also set binary data using `configMap.setBinaryData()`.
+   */
+  readonly binaryData?: { [key: string]: string };
+
+  /**
+   * Array of .env files to load into the config map's data.
+   *
+   * You can also set data using `configMap.setFromEnvFile()`.
+   */
+  readonly envFiles?: string[];
+
+  /**
+   * Whether to not include the content-based suffix hash in the name.
+   * Mimics the behavior of a generator from `kustomize`.
+   * @see https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/generatoroptions/
+   * @default false
+   */
+  readonly disableNameSuffixHash?: boolean;
+}
+
+export class ConfigMap extends Construct {
+  public readonly disableNameSuffixHash: boolean;
+  private readonly apiObject: ApiObject;
+  private readonly _binaryData: { [key: string]: string } = {};
+  private readonly _data: { [key: string]: string } = {};
+  private _hash?: string;
+
+  public constructor(scope: Construct, id: string, props: ConfigMapProps = {}) {
+    super(scope, id);
+
+    this.disableNameSuffixHash = props.disableNameSuffixHash ?? false;
+
+    const labels: { [x: string]: string } = {};
+    if (!this.disableNameSuffixHash) {
+      labels.prunable = "true";
+    }
+
+    this.apiObject = new KubeConfigMap(this, id, {
+      metadata: {
+        ...props?.metadata,
+        labels: {
+          ...props?.metadata?.labels,
+          ...labels,
+        },
+        // we need lazy here to compute name based on contents
+        name: Lazy.any({
+          produce: () => this.computeName(props?.metadata?.name),
+        }),
+      },
+      immutable: props.immutable,
+      // we need lazy here because we filter empty
+      data: Lazy.any({ produce: () => this.synthesizeData() }),
+      binaryData: Lazy.any({
+        produce: () => this.synthesizeBinaryData(),
+      }),
+    });
+
+    for (const [key, value] of Object.entries(props.data ?? {})) {
+      this.setData(key, value);
+    }
+
+    for (const [key, value] of Object.entries(props.binaryData ?? {})) {
+      this.setBinaryData(key, value);
+    }
+
+    for (const envFile of props.envFiles ?? []) {
+      this.setFromEnvFile(envFile);
+    }
+  }
+
+  /**
+   * The name of this ConfigMap.
+   */
+  public get name(): string {
+    return this.apiObject.name;
+  }
+
+  /**
+   * The metadata of this ConfigMap.
+   */
+  public get metadata(): ApiObjectMetadataDefinition {
+    return this.apiObject.metadata;
+  }
+
+  /**
+   * Sets a data entry.
+   * @param key The key
+   * @param value The value
+   *
+   * @throws if there is a `binaryData` entry with the same key
+   */
+  public setData(key: string, value: string): void {
+    this.verifyKeyAvailable(key, "_binaryData");
+    this.invalidateHash();
+
+    this._data[key] = value;
+  }
+
+  /**
+   * The data associated with this config map.
+   *
+   * Returns an copy. To set data records, use `setData()` or `setBinaryData()`.
+   */
+  public get data(): Record<string, string> {
+    return { ...this._data };
+  }
+
+  /**
+   * Sets a binary data entry. BinaryData can contain byte
+   * sequences that are not in the UTF-8 range.
+   * @param key The key
+   * @param value The value
+   *
+   * @throws if there is a `data` entry with the same key
+   */
+  public setBinaryData(key: string, value: string): void {
+    this.verifyKeyAvailable(key, "_data");
+    this.invalidateHash();
+
+    this._binaryData[key] = value;
+  }
+
+  /**
+   * The binary data associated with this config map.
+   *
+   * Returns a copy. To set data records, use `setBinaryData()` or `setData()`.
+   */
+  public get binaryData(): Record<string, string> {
+    return { ...this._binaryData };
+  }
+
+  /**
+   * Sets an entry with a file's contents.
+   * @param localFile The path to the local file
+   * @param key The ConfigMap key (default to the file name).
+   */
+  public setFile(localFile: string, key?: string): void {
+    key = key ?? basename(localFile);
+    const value = readFileSync(localFile, "utf-8");
+
+    this.setData(key, value);
+  }
+
+  /**
+   * Sets an entry with a binary file's contents.
+   * @param localFile The path to the local file
+   * @param key The ConfigMap key (default to the file name).
+   */
+  public setBinaryFile(localFile: string, key?: string): void {
+    key = key ?? basename(localFile);
+    const value = readFileSync(localFile, "utf-8");
+
+    this.setBinaryData(key, value);
+  }
+
+  /**
+   * Sets data entries from a .env file.
+   * @param localFile The path to the .env file.
+   */
+  public setFromEnvFile(localFile: string): void {
+    const parsed = parse(readFileSync(localFile, "utf-8"));
+
+    for (const [key, value] of Object.entries(parsed)) {
+      this.setData(key, value);
+    }
+  }
+
+  /**
+   * Invalidate the hash so that it will be recomputed.
+   */
+  private invalidateHash(): void {
+    this._hash = undefined;
+  }
+
+  /**
+   * Verify we're not setting the same key in both `data` and `binaryData`.
+   * @param key The key to verify
+   * @param where Where the key _shouldn't_ be already used
+   */
+  private verifyKeyAvailable(
+    key: string,
+    where: "_data" | "_binaryData"
+  ): void {
+    if (key in this[where]) {
+      throw new Error(
+        `ConfigMap key "${key}" is already used in ${where.substring(1)}`
+      );
+    }
+  }
+
+  private synthesizeData(): { [key: string]: string } | undefined {
+    if (Object.keys(this._data).length === 0) {
+      return undefined;
+    }
+
+    return this._data;
+  }
+
+  private synthesizeBinaryData(): { [key: string]: string } | undefined {
+    if (Object.keys(this._binaryData).length === 0) {
+      return undefined;
+    }
+
+    return this._binaryData;
+  }
+
+  /**
+   * Compute the name of the config map, including the hash.
+   * @param basename The base name of the config map.
+   */
+  private computeName(basename?: string): string {
+    const name =
+      basename ?? this.apiObject.chart.generateObjectName(this.apiObject);
+
+    if (this.disableNameSuffixHash) {
+      return name;
+    }
+
+    if (!this._hash) {
+      this._hash = this.computeHash(name);
+    }
+
+    return `${name}-${this._hash}`;
+  }
+
+  /**
+   * Compute hash of the object itself.
+   * @param name The name of the config map.
+   */
+  private computeHash(name: string): string {
+    const object: Record<string, string | Record<string, string>> = {
+      kind: this.apiObject.kind,
+      name,
+      data: this.data,
+    };
+    if (Object.keys(this.binaryData).length > 0) {
+      object.binaryData = this.binaryData;
+    }
+
+    return hashObject(object);
+  }
+}

--- a/lib/data/hash-util.ts
+++ b/lib/data/hash-util.ts
@@ -1,0 +1,44 @@
+import { createHash } from "crypto";
+import sortKeys from "sort-keys";
+
+/**
+ * Shorten a hash and prevent bad words from being formed.
+ * Copied from https://github.com/kubernetes/kubernetes/blob/v1.22.4/staging/src/k8s.io/kubectl/pkg/util/hash/hash.go#L97-L125
+ * @param hex Hash to encode
+ */
+function encodeHash(hex: string): string {
+  const encoded = hex
+    .substring(0, 10)
+    .split("")
+    .map((character) => {
+      switch (character) {
+        case "0":
+          return "g";
+        case "1":
+          return "h";
+        case "3":
+          return "k";
+        case "a":
+          return "m";
+        case "e":
+          return "t";
+        default:
+          return character;
+      }
+    })
+    .join("");
+  return encoded;
+}
+
+/**
+ * Compute the hash of API object.
+ * Copied from https://github.com/kubernetes/kubernetes/blob/v1.22.4/staging/src/k8s.io/kubectl/pkg/util/hash/hash.go#L55-L75
+ * @param object Object to hash
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function hashObject(object: Record<string, any>): string {
+  const serialised = JSON.stringify(sortKeys(object, { deep: true }));
+  const hash = createHash("sha256").update(serialised, "utf8").digest("hex");
+
+  return encodeHash(hash);
+}

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -1,0 +1,2 @@
+export * from "./config-map";
+export * from "./secret";

--- a/lib/data/secret.ts
+++ b/lib/data/secret.ts
@@ -1,0 +1,267 @@
+import {
+  ApiObject,
+  ApiObjectMetadata,
+  ApiObjectMetadataDefinition,
+  Lazy,
+} from "cdk8s";
+import { Construct } from "constructs";
+import { parse } from "dotenv";
+import { readFileSync } from "fs";
+import { basename } from "path";
+import { KubeSecret } from "../../imports/k8s";
+import { hashObject } from "./hash-util";
+
+export interface SecretProps {
+  /**
+   * Metadata that all persisted resources must have, which includes all objects
+   * users must create.
+   */
+  readonly metadata?: ApiObjectMetadata;
+
+  /**
+   * Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+   */
+  readonly immutable?: boolean;
+
+  /**
+   * Map of key/value pairs of binary data e.g. 'environment variable'.
+   *
+   * You can also set data using `secret.setData()`.
+   */
+  readonly data?: { [key: string]: string };
+
+  /**
+   * Map of key/value pairs of non-binary data e.g. 'filename' = 'contents'.
+   *
+   * You can also set non-binary data using `secret.setStringData()`.
+   */
+  readonly stringData?: { [key: string]: string };
+
+  /**
+   * Optional type associated with the secret. Used to facilitate programmatic
+   * handling of secret data by various controllers.
+   */
+  readonly type?: string;
+
+  /**
+   * Array of .env files to load into the secret's data.
+   *
+   * You can also set data using `secret.setFromEnvFile()`.
+   */
+  readonly envFiles?: string[];
+
+  /**
+   * Whether to not include the content-based suffix hash in the name.
+   * Mimics the behavior of a generator from `kustomize`.
+   * @see https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/generatoroptions/
+   * @default false
+   */
+  readonly disableNameSuffixHash?: boolean;
+}
+
+export class Secret extends Construct {
+  public readonly disableNameSuffixHash: boolean;
+
+  protected readonly apiObject: ApiObject;
+
+  private readonly _stringData: { [key: string]: string } = {};
+  private readonly _data: { [key: string]: string } = {};
+  private _hash?: string;
+
+  public constructor(scope: Construct, id: string, props: SecretProps = {}) {
+    super(scope, id);
+
+    this.disableNameSuffixHash = props.disableNameSuffixHash ?? false;
+
+    const labels: { [x: string]: string } = {};
+    if (!this.disableNameSuffixHash) {
+      labels.prunable = "true";
+    }
+
+    this.apiObject = new KubeSecret(this, id, {
+      metadata: {
+        ...props?.metadata,
+        labels: {
+          ...props?.metadata?.labels,
+          ...labels,
+        },
+        // we need lazy here to compute name based on contents
+        name: Lazy.any({
+          produce: () => this.computeName(props?.metadata?.name),
+        }),
+      },
+      immutable: props.immutable,
+      type: props.type,
+      // we need lazy here because we filter empty
+      data: Lazy.any({ produce: () => this.synthesizeData() }),
+      stringData: Lazy.any({
+        produce: () => this.synthesizeStringData(),
+      }),
+    });
+
+    for (const [key, value] of Object.entries(props.data ?? {})) {
+      this.setData(key, value);
+    }
+
+    for (const [key, value] of Object.entries(props.stringData ?? {})) {
+      this.setStringData(key, value);
+    }
+
+    for (const envFile of props.envFiles ?? []) {
+      this.setFromEnvFile(envFile);
+    }
+  }
+
+  /**
+   * The name of this Secret.
+   */
+  public get name(): string {
+    return this.apiObject.name;
+  }
+
+  /**
+   * The metadata of this ConfigMap.
+   */
+  public get metadata(): ApiObjectMetadataDefinition {
+    return this.apiObject.metadata;
+  }
+
+  /**
+   * Sets a data entry. Data can contain byte sequences that are not in the UTF-8 range.
+   * @param key The key
+   * @param value The value
+   */
+  public setData(key: string, value: string): void {
+    this.invalidateHash();
+
+    this._data[key] = value;
+  }
+
+  /**
+   * The data associated with this secret.
+   *
+   * Returns an copy. To set data records, use `setData()` or `setStringData()`.
+   */
+  public get data(): Record<string, string> {
+    return { ...this._data };
+  }
+
+  /**
+   * Sets a string data entry.
+   *
+   * All keys and values are merged into the data
+   * field on write, overwriting any existing values. The stringData field
+   * is never output when reading from the API.
+   * @param key The key
+   * @param value The value
+   */
+  public setStringData(key: string, value: string): void {
+    this.invalidateHash();
+
+    this._stringData[key] = value;
+  }
+
+  /**
+   * The binary data associated with this secret.
+   *
+   * Returns a copy. To set data records, use `setStringData()` or `setData()`.
+   */
+  public get stringData(): Record<string, string> {
+    return { ...this._stringData };
+  }
+
+  /**
+   * Sets an entry with a file's contents.
+   * @param localFile The path to the local file
+   * @param key The Secret key (default to the file name).
+   */
+  public setFile(localFile: string, key?: string): void {
+    key = key ?? basename(localFile);
+    const value = readFileSync(localFile, "utf-8");
+
+    this.setData(key, value);
+  }
+
+  /**
+   * Sets an entry with a binary file's contents.
+   * @param localFile The path to the local file
+   * @param key The Secret key (default to the file name).
+   */
+  public setStringFile(localFile: string, key?: string): void {
+    key = key ?? basename(localFile);
+    const value = readFileSync(localFile, "utf-8");
+
+    this.setStringData(key, value);
+  }
+
+  /**
+   * Sets data entries from a .env file.
+   * @param localFile The path to the .env file.
+   */
+  public setFromEnvFile(localFile: string): void {
+    const parsed = parse(readFileSync(localFile, "utf-8"));
+
+    for (const [key, value] of Object.entries(parsed)) {
+      this.setData(key, value);
+    }
+  }
+
+  /**
+   * Invalidate the hash so that it will be recomputed.
+   */
+  private invalidateHash(): void {
+    this._hash = undefined;
+  }
+
+  private synthesizeData(): { [key: string]: string } | undefined {
+    if (Object.keys(this._data).length === 0) {
+      return undefined;
+    }
+
+    return this._data;
+  }
+
+  private synthesizeStringData(): { [key: string]: string } | undefined {
+    if (Object.keys(this._stringData).length === 0) {
+      return undefined;
+    }
+
+    return this._stringData;
+  }
+
+  /**
+   * Compute the name of the secret, including the hash.
+   * @param basename The base name of the secret.
+   */
+  private computeName(basename?: string): string {
+    const name =
+      basename ?? this.apiObject.chart.generateObjectName(this.apiObject);
+
+    if (this.disableNameSuffixHash) {
+      return name;
+    }
+
+    if (!this._hash) {
+      this._hash = this.computeHash(name);
+    }
+
+    return `${name}-${this._hash}`;
+  }
+
+  /**
+   * Compute hash of the object itself.
+   * @param name The name of the secret.
+   */
+  private computeHash(name: string): string {
+    const object: Record<string, string | Record<string, string>> = {
+      kind: this.apiObject.kind,
+      name,
+      data: this.data,
+    };
+    if (Object.keys(this.stringData).length > 0) {
+      object.stringData = this.stringData;
+    }
+
+    return hashObject(object);
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
+export * from "./data";
 export * from "./web-service";

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,34 +7,40 @@
     "": {
       "name": "talis-cdk8s-constructs",
       "version": "0.1.0",
+      "dependencies": {
+        "dotenv": "^13.0.1",
+        "sort-keys": "^4.2.0"
+      },
       "devDependencies": {
-        "@commitlint/cli": "^16.0.2",
+        "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
         "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.178",
-        "@types/node": "^17.0.8",
-        "@typescript-eslint/eslint-plugin": "^5.9.1",
-        "@typescript-eslint/parser": "^5.9.1",
-        "cdk8s": "^2.1.10",
-        "cdk8s-cli": "^1.0.77",
-        "constructs": "^10.0.33",
-        "eslint": "^8.6.0",
+        "@types/mock-fs": "^4.13.1",
+        "@types/node": "^17.0.12",
+        "@typescript-eslint/eslint-plugin": "^5.10.1",
+        "@typescript-eslint/parser": "^5.10.1",
+        "cdk8s": "^2.1.21",
+        "cdk8s-cli": "^1.0.83",
+        "constructs": "^10.0.44",
+        "eslint": "^8.7.0",
         "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-jest": "^25.3.4",
+        "eslint-plugin-jest": "^26.0.0",
         "husky": "^7.0.4",
         "jest": "^27.4.7",
         "jest-junit": "^13.0.0",
-        "lint-staged": "^12.1.7",
+        "lint-staged": "^12.3.1",
         "lodash": "^4.17.21",
+        "mock-fs": "^5.1.2",
         "prettier": "^2.5.1",
-        "semantic-release": "^18.0.1",
-        "ts-jest": "^27.1.2",
+        "semantic-release": "^19.0.2",
+        "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "cdk8s": "^2.1.10",
-        "constructs": "^10.0.33"
+        "cdk8s": "^2.1.21",
+        "constructs": "^10.0.44"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -625,14 +631,14 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.0.2.tgz",
-      "integrity": "sha512-Jt7iaBjoLGC5Nq4dHPTvTYnqPGkElFPBtTXTvBpTgatZApczyjI2plE0oG4GYWPp1suHIS/VdVDOMpPZjGVusg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.1.0.tgz",
+      "integrity": "sha512-x5L1knvA3isRWBRVQx+Q6D45pA9139a2aZQYpxkljMG0dj4UHZkCnsYWpnGalxPxASI7nrI0KedKfS2YeQ55cQ==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^16.0.0",
         "@commitlint/lint": "^16.0.0",
-        "@commitlint/load": "^16.0.0",
+        "@commitlint/load": "^16.1.0",
         "@commitlint/read": "^16.0.0",
         "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19",
@@ -660,9 +666,9 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
-      "integrity": "sha512-i80DGlo1FeC5jZpuoNV9NIjQN/m2dDV3jYGWg+1Wr+KldptkUHXj+6GY1Akll66lJ3D8s6aUGi3comPLHPtWHg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.1.0.tgz",
+      "integrity": "sha512-2cHeZPNTuf1JWbMqyA46MkExor5HMSgv8JrdmzEakUbJHUreh35/wN00FJf57qGs134exQW2thiSQ1IJUsVx2Q==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^16.0.0",
@@ -736,14 +742,14 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.0.0.tgz",
-      "integrity": "sha512-7WhrGCkP6K/XfjBBguLkkI2XUdiiIyMGlNsSoSqgRNiD352EiffhFEApMy1/XOU+viwBBm/On0n5p0NC7e9/4A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.1.0.tgz",
+      "integrity": "sha512-MtlEhKjP8jAF85jjX4mw8DUUwCxKsCgAc865hhpnwxjrfBcmGP7Up2AFE/M3ZMGDmSl1X1TMybQk/zohj8Cqdg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/config-validator": "^16.1.0",
         "@commitlint/execute-rule": "^16.0.0",
-        "@commitlint/resolve-extends": "^16.0.0",
+        "@commitlint/resolve-extends": "^16.1.0",
         "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -795,12 +801,12 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.0.0.tgz",
-      "integrity": "sha512-Z/w9MAQUcxeawpCLtjmkVNXAXOmB2nhW+LYmHEZcx9O6UTauF/1+uuZ2/r0MtzTe1qw2JD+1QHVhEWYHVPlkdA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.1.0.tgz",
+      "integrity": "sha512-8182s6AFoUFX6+FT1PgQDt15nO2ogdR/EN8SYVAdhNXw1rLz8kT5saB/ICw567GuRAUgFTUMGCXy3ctMOXPEDg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/config-validator": "^16.1.0",
         "@commitlint/types": "^16.0.0",
         "import-fresh": "^3.0.0",
         "lodash": "^4.17.19",
@@ -1560,9 +1566,9 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
+      "integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
@@ -1572,7 +1578,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1580,10 +1586,10 @@
         "tempy": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16 || ^14.17"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0"
+        "semantic-release": ">=19.0.0"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -1763,10 +1769,19 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "node_modules/@types/mock-fs": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+      "integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1815,14 +1830,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
-      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/type-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/type-utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1847,39 +1862,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
-      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/typescript-estree": "5.10.1",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1899,13 +1890,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/visitor-keys": "5.10.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1916,12 +1907,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
-      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/utils": "5.10.1",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1942,9 +1933,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1955,13 +1946,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/visitor-keys": "5.10.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1981,13 +1972,37 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.1",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/typescript-estree": "5.10.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.10.1",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -2104,15 +2119,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2544,9 +2550,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.10.tgz",
-      "integrity": "sha512-MfFlhX31ysw8zUtGXIvoRjh20v+KVwAHHXaRtMdtYcrxVzwvgtLB2mGvhHoqvowhStDWX6rTKCniG8QirCqkeA==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.21.tgz",
+      "integrity": "sha512-+R6n0k7i3YSZIKKyv2rhGuTJrhg7SUF6Ursvgp6mWYbDYTYO3yoZbhvOsoDVv/tXG8y4zC4RVEDffAcg8Hr8kg==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -2566,23 +2572,23 @@
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "1.0.77",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.77.tgz",
-      "integrity": "sha512-v/4VymNP23+z/cWIKvUdmyNd8OqcXmD9k3MK4OxiUT4EMocoGmcXT72zJ1T15jDONtEw1cEJ0Y+nHSB9RNoOXg==",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.83.tgz",
+      "integrity": "sha512-Iq+HoB3QeuEFMjOWZs/oTrNmsQ4Xqin1ukIu0j4RsqJ+YF6x1v+y8wro4goL5EkhaE7+CNbkSNbOa3KfnlFivg==",
       "dev": true,
       "dependencies": {
         "@types/node": "^12.13.0",
-        "ajv": "^8.8.2",
-        "cdk8s": "^1.4.0",
-        "cdk8s-plus-22": "^1.0.0-beta.85",
+        "ajv": "^8.9.0",
+        "cdk8s": "^1.4.10",
+        "cdk8s-plus-22": "^1.0.0-beta.96",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.187",
+        "constructs": "^3.3.197",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.444",
-        "json2jsii": "^0.2.104",
-        "sscaff": "^1.2.170",
+        "jsii-srcmak": "^0.1.454",
+        "json2jsii": "^0.2.114",
+        "sscaff": "^1.2.180",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -2600,9 +2606,9 @@
       "dev": true
     },
     "node_modules/cdk8s-cli/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2625,9 +2631,9 @@
       }
     },
     "node_modules/cdk8s-cli/node_modules/cdk8s": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.0.tgz",
-      "integrity": "sha512-thdjQcCcDKN7flQiDuQycD+lhKoQxTSVxw231d8ibMyKrZTzVAJhBvHqVnx3nN+buPdEfW+epGi3ISKmTT8hLw==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.12.tgz",
+      "integrity": "sha512-RZO4LA78osAHNiy1jAU+BeXbhNJUCt+MGPoUuDztJcn7f7OlbnSB67gviUUN2hLiJZYRp4xI/3UfB1J+mB9JdA==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -2643,13 +2649,13 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "constructs": "^3.3.186"
+        "constructs": "^3.3.198"
       }
     },
     "node_modules/cdk8s-cli/node_modules/cdk8s-plus-22": {
-      "version": "1.0.0-beta.85",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.85.tgz",
-      "integrity": "sha512-FV/7/MQX3cAUiHRxJ+fTgMPprGEjFrBBU1CW7N0sRiCMvSiK8RKTBFw5AtNAUsPbTH70wKa1e2eu90HOXNBfDw==",
+      "version": "1.0.0-beta.98",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.98.tgz",
+      "integrity": "sha512-bbWYZIybpT8RsSOSPLAKVUEtPGhyQJGUQluvQxjVWFhricHBEorMu92HeYbdw10pBEFxiB2MFsVIXO/90pk6gQ==",
       "bundleDependencies": [
         "minimatch"
       ],
@@ -2661,8 +2667,8 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "cdk8s": "^1.3.32",
-        "constructs": "^3.3.186"
+        "cdk8s": "^1.4.11",
+        "constructs": "^3.3.198"
       }
     },
     "node_modules/cdk8s-cli/node_modules/cdk8s-plus-22/node_modules/balanced-match": {
@@ -2758,9 +2764,9 @@
       }
     },
     "node_modules/cdk8s-cli/node_modules/constructs": {
-      "version": "3.3.187",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.187.tgz",
-      "integrity": "sha512-0Y2R9cTV7+ASjPpFkOYCb3cA7BJRM1OVVwJfZCEUa+Nxpq7EK9K9hoz/8FuvQBVQV3hCu+VisEC5iDcM/Dg2qw==",
+      "version": "3.3.199",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.199.tgz",
+      "integrity": "sha512-BKkU/yKQGwauX9lQR9jhw13l5vch3g9tgvUQyoKDoKPJp7+x8OhXmHmI+OZInonGAWz1g8BzKDtVS+Mj7nIGag==",
       "dev": true,
       "engines": {
         "node": ">= 12.7.0"
@@ -3260,9 +3266,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.33.tgz",
-      "integrity": "sha512-1lyxVYjD2yNSlDMryiktmgv/fzN+ykPqEYD5UJKdGerbwFjUd+LTl+rNiGqxob9POPVt49Ez0FXnm0/di6LQng==",
+      "version": "10.0.44",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.44.tgz",
+      "integrity": "sha512-DNcxbAEtJHCUTwDijBlRDfMBAQUdfM+9Yprx3lJcYpOL9+DfuORB9fK9nKCQ3igmN/kv+I1hVg2Lqe+aVl/W5A==",
       "dev": true,
       "engines": {
         "node": ">= 12.7.0"
@@ -3392,9 +3398,9 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.3.tgz",
-      "integrity": "sha512-ARo21VjxdacJUcHxgVMEYNIoVPYiuKOEwWBIYej4M22+pEbe3LzKgmht2UPM+0u7/T/KnZf2r/5IzHv2Nwz+/w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.4.tgz",
+      "integrity": "sha512-ulv2dvwurP/MZAIthXm69bO7EzzIUThZ6RJ1qXhdlXM6to3F+IKBL/17EnhYSG52A5N1KcAUu66vSG/3/77KrA==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^7",
@@ -3496,9 +3502,9 @@
       }
     },
     "node_modules/date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -3802,6 +3808,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-13.0.1.tgz",
+      "integrity": "sha512-u3KAkK+VHk01+D7V6SFtSJl2JScX1Yi4anKsKXS4oT8s8LnL5xgJe7XFAZ1bSsOfAmxU54OwOuhaLv3v70oXgw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -3870,18 +3884,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/entities": {
       "version": "2.0.3",
@@ -4086,9 +4088,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -4098,11 +4100,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -4111,7 +4112,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -4122,9 +4123,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -4153,18 +4152,18 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "25.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.3.4.tgz",
-      "integrity": "sha512-CCnwG71wvabmwq/qkz0HWIqBHQxw6pXB1uqt24dxqJ9WB34pVg49bL1sjXphlJHgTMWGhBjN1PicdyxDxrfP5A==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz",
+      "integrity": "sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.0.0"
+        "@typescript-eslint/utils": "^5.10.0"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -4217,9 +4216,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4245,15 +4244,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/espree": {
@@ -6641,9 +6631,9 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.444",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.444.tgz",
-      "integrity": "sha512-49yN6OSHwC1waMVtT+JhkU/hX0j+/dQFJMOksyxyH7y95SvMAICfCWmdgXBNg7p0/j5XkCKMfeSsRwnp7+K2Lg==",
+      "version": "0.1.456",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.456.tgz",
+      "integrity": "sha512-xvfSOidghzTr2rj63oEVujk6/0fksqA+YmakFTZxmaX1bFJHGLkEzGiS3y/f3v4Tl1+hKgXxakWYx0tzL+mNQQ==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
@@ -6890,9 +6880,9 @@
       "dev": true
     },
     "node_modules/json2jsii": {
-      "version": "0.2.104",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.104.tgz",
-      "integrity": "sha512-I1UranAsUn4otinldDvdghKOvd5Q9YD+Q9FgUD0zR/zG+F6G3PUqbZoi6RQRdu2g5nFxV7KfSkF041C8EPR+Yw==",
+      "version": "0.2.116",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.116.tgz",
+      "integrity": "sha512-ffc4HhaYRnY1s1kfAKRJAobWg+v9OLu9pYEFRKzWgfuLLyOjZTcu/MZMWLOYribm4vIbA2lJQInlipeKWKq2hg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -7020,9 +7010,9 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "12.1.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
-      "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.1.tgz",
+      "integrity": "sha512-Ocht/eT+4/siWOZDJpNUKcKX2UeWW/pDbohJ4gRsrafAjBi79JK8kiNVk2ciIVNKdw0Q4ABptl2nr6uQAlRImw==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^3.1.0",
@@ -7031,10 +7021,10 @@
         "debug": "^4.3.3",
         "execa": "^5.1.1",
         "lilconfig": "2.0.4",
-        "listr2": "^3.13.5",
+        "listr2": "^4.0.1",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
-        "object-inspect": "^1.11.1",
+        "object-inspect": "^1.12.0",
         "string-argv": "^0.3.1",
         "supports-color": "^9.2.1",
         "yaml": "^1.10.2"
@@ -7071,9 +7061,9 @@
       }
     },
     "node_modules/listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.1.tgz",
+      "integrity": "sha512-D65Nl+zyYHL2jQBGmxtH/pU8koPZo5C8iCNE8EoB04RwPgQG1wuaKwVbeZv9LJpiH4Nxs0FCp+nNcG8OqpniiA==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
@@ -7081,12 +7071,12 @@
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
+        "rxjs": "^7.5.2",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12"
       },
       "peerDependencies": {
         "enquirer": ">= 2.3.0 < 3"
@@ -7298,26 +7288,20 @@
       }
     },
     "node_modules/log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",
       "dev": true,
       "dependencies": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       },
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/log4js/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-      "dev": true
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -7392,32 +7376,74 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/marked-terminal": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
-      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.0.0.tgz",
+      "integrity": "sha512-26604GmGmW63ElxcXpE2xfMdbtgD/qiwIqOh/+5+uPe6NVU4bU433+wvPTfq6NZcGr16KWqwu/dzsKxg3IL2Xw==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
+        "chalk": "^5.0.0",
         "cli-table3": "^0.6.0",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": " >=14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0"
+        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+      "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdurl": {
@@ -7586,6 +7612,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mock-fs": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -7730,9 +7765,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.3.2.tgz",
+      "integrity": "sha512-xZAC9GpWNOyiS1TtBqBy0HJpjIVI8zsVXEOEwcmgqYFtqOy7sXUL0ByOrkhfcGmf+akSXz3uOxLYB8aLlYivQQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7789,6 +7824,7 @@
         "opener",
         "pacote",
         "parse-conflict-json",
+        "proc-log",
         "qrcode-terminal",
         "read",
         "read-package-json",
@@ -7862,6 +7898,7 @@
         "opener": "*",
         "pacote": "*",
         "parse-conflict-json": "*",
+        "proc-log": "*",
         "qrcode-terminal": "*",
         "read": "*",
         "read-package-json": "*",
@@ -7883,7 +7920,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm-run-path": {
@@ -7911,21 +7948,21 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.9.0",
+      "version": "4.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@isaacs/string-locale-compare": "^1.0.1",
+        "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^1.0.2",
-        "@npmcli/metavuln-calculator": "^1.1.0",
+        "@npmcli/map-workspaces": "^2.0.0",
+        "@npmcli/metavuln-calculator": "^2.0.0",
         "@npmcli/move-file": "^1.1.0",
         "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/node-gyp": "^1.0.3",
         "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.2",
-        "bin-links": "^2.2.1",
+        "@npmcli/run-script": "^2.0.0",
+        "bin-links": "^3.0.0",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
@@ -7936,8 +7973,8 @@
         "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
+        "pacote": "^12.0.2",
+        "parse-conflict-json": "^2.0.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.1",
@@ -7953,17 +7990,17 @@
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8033,7 +8070,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.4",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8044,18 +8081,22 @@
         "read-package-json-fast": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "1.1.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^15.0.5",
-        "pacote": "^11.1.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "pacote": "^12.0.0",
         "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
@@ -8078,7 +8119,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -8102,14 +8143,14 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.6",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^7.1.0",
+        "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
       }
     },
@@ -8141,7 +8182,7 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.1.4",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8165,22 +8206,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
@@ -8232,7 +8257,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.6",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8250,75 +8275,27 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/asn1": {
-      "version": "0.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/aws4": {
-      "version": "1.11.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "2.2.1",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^4.0.1",
-        "mkdirp": "^1.0.3",
+        "mkdirp-infer-owner": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0",
         "read-cmd-shim": "^2.0.0",
         "rimraf": "^3.0.0",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
@@ -8375,12 +8352,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/caseless": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -8428,16 +8399,60 @@
       }
     },
     "node_modules/npm/node_modules/cli-columns": {
-      "version": "3.1.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.1"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
@@ -8521,15 +8536,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -8577,18 +8583,6 @@
         "wcwidth": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
@@ -8606,24 +8600,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/dashdash": {
-      "version": "1.14.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.2",
@@ -8666,15 +8642,6 @@
         "clone": "^1.0.2"
       }
     },
-    "node_modules/npm/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
       "dev": true,
@@ -8709,16 +8676,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -8750,47 +8707,11 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/extsprintf": {
-      "version": "1.3.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/forever-agent": {
-      "version": "0.6.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -8817,32 +8738,67 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "ansi-regex": "^5.0.1",
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
         "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1 || ^2.0.0",
-        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
-    "node_modules/npm/node_modules/getpass": {
-      "version": "0.1.7",
+    "node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "assert-plus": "^1.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/glob": {
@@ -8870,28 +8826,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/har-schema": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/har-validator": {
-      "version": "5.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
@@ -8921,7 +8855,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "4.0.2",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8950,21 +8884,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/http-signature": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
@@ -9003,12 +8922,15 @@
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "3.0.4",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -9106,7 +9028,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9144,31 +9066,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/isstream": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "0.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-schema": {
-      "version": "0.2.3",
-      "dev": true,
-      "inBundle": true
-    },
-    "node_modules/npm/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -9182,12 +9081,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
       "dev": true,
@@ -9197,35 +9090,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/jsprim": {
-      "version": "1.4.1",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "3.1.1",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "3.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "4.0.3",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9236,11 +9114,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "2.0.4",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9251,46 +9129,49 @@
         "diff": "^5.0.0",
         "minimatch": "^3.0.4",
         "npm-package-arg": "^8.1.4",
-        "pacote": "^11.3.4",
+        "pacote": "^12.0.0",
         "tar": "^6.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/arborist": "^4.0.0",
         "@npmcli/ci-detect": "^1.3.0",
-        "@npmcli/run-script": "^1.8.4",
+        "@npmcli/run-script": "^2.0.0",
         "chalk": "^4.1.0",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-package-arg": "^8.1.2",
-        "pacote": "^11.3.1",
+        "pacote": "^12.0.0",
         "proc-log": "^1.0.0",
         "read": "^1.0.7",
         "read-package-json-fast": "^2.0.2",
         "walk-up-path": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "1.1.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.5.0"
+        "@npmcli/arborist": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "6.0.3",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9299,11 +9180,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9312,25 +9193,25 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "2.0.1",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/run-script": "^1.8.3",
+        "@npmcli/run-script": "^2.0.0",
         "npm-package-arg": "^8.1.0",
-        "pacote": "^11.2.6"
+        "pacote": "^12.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "4.0.2",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9342,11 +9223,11 @@
         "ssri": "^8.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "3.1.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9354,11 +9235,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "2.0.4",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9367,20 +9248,23 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "1.2.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^2.0.7",
-        "@npmcli/run-script": "^1.8.4",
+        "@npmcli/run-script": "^2.0.0",
         "json-parse-even-better-errors": "^2.3.1",
         "semver": "^7.3.5",
         "stringify-package": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
@@ -9422,27 +9306,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/mime-db": {
-      "version": "1.49.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.32",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.49.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
       "dev": true,
@@ -9456,7 +9319,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.5",
+      "version": "3.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9603,20 +9466,20 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "7.1.2",
+      "version": "8.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
         "nopt": "^5.0.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.2",
+        "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
         "which": "^2.0.2"
       },
       "bin": {
@@ -9624,66 +9487,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
-      "version": "4.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
@@ -9770,13 +9573,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "2.2.2",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.6",
-        "ignore-walk": "^3.0.3",
+        "ignore-walk": "^4.0.1",
         "npm-bundled": "^1.1.1",
         "npm-normalize-package-bin": "^1.0.1"
       },
@@ -9835,46 +9638,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "5.0.1",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
+        "gauge": "^4.0.0",
         "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/object-assign": {
@@ -9920,7 +9695,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.5",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9928,7 +9703,7 @@
         "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.8.2",
+        "@npmcli/run-script": "^2.0.0",
         "cacache": "^15.0.5",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -9936,7 +9711,7 @@
         "minipass": "^3.1.3",
         "mkdirp": "^1.0.3",
         "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^2.1.4",
+        "npm-packlist": "^3.0.0",
         "npm-pick-manifest": "^6.0.0",
         "npm-registry-fetch": "^11.0.0",
         "promise-retry": "^2.0.1",
@@ -9949,18 +9724,21 @@
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "1.1.1",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "just-diff": "^3.0.1",
-        "just-diff-apply": "^3.0.0"
+        "json-parse-even-better-errors": "^2.3.1",
+        "just-diff": "^5.0.1",
+        "just-diff-apply": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/path-is-absolute": {
@@ -9971,12 +9749,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/npm/node_modules/performance-now": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "1.0.0",
@@ -10030,36 +9802,12 @@
         "read": "1"
       }
     },
-    "node_modules/npm/node_modules/psl": {
-      "version": "1.8.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/npm/node_modules/qs": {
-      "version": "6.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/npm/node_modules/read": {
@@ -10134,64 +9882,6 @@
         "once": "^1.3.0"
       }
     },
-    "node_modules/npm/node_modules/request": {
-      "version": "2.88.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -10240,7 +9930,8 @@
       "version": "2.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.5",
@@ -10264,7 +9955,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.3",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -10338,31 +10029,6 @@
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sshpk": {
-      "version": "1.16.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "8.0.1",
@@ -10484,32 +10150,25 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "Unlicense"
-    },
     "node_modules/npm/node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
+      "version": "4.0.0",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
@@ -10529,29 +10188,11 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "node_modules/npm/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/uuid": {
-      "version": "3.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -10570,20 +10211,6 @@
       "license": "ISC",
       "dependencies": {
         "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/npm/node_modules/verror": {
-      "version": "1.10.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
@@ -10632,7 +10259,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "3.0.3",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10640,7 +10267,10 @@
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
+        "typedarray-to-buffer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -11171,15 +10801,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11443,9 +11064,9 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -11675,15 +11296,15 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.1.tgz",
-      "integrity": "sha512-xTdKCaEnCzHr+Fqyhg/5I8P9pvY9z7WHa8TFCYIwcdPbuzAtQShOTzw3VNPsqBT+Yq1kFyBQFBKBYkGOlqWmfA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
         "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
@@ -11697,8 +11318,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -11713,7 +11334,7 @@
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16 || ^14.17"
       }
     },
     "node_modules/semantic-release/node_modules/yargs": {
@@ -12032,6 +11653,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sort-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "dependencies": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12129,9 +11772,9 @@
       "dev": true
     },
     "node_modules/sscaff": {
-      "version": "1.2.170",
-      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.170.tgz",
-      "integrity": "sha512-h+P/7sNWh9hzKGbymcbuweb0t3VusiCEagUN+Rlk/qUR8W0fzQE80xMpKYe4qlQUHItWMi5JnYhM0KbM/IASNQ==",
+      "version": "1.2.182",
+      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.182.tgz",
+      "integrity": "sha512-b1zHT4Xfl4pAxc+wcUSmBeijtn6aveO4+3oGRLrNCrHvrh3RsU1kTrkkVBUhYsYDafxW8GeSOJ/rdLmiT3xa4A==",
       "dev": true,
       "engines": {
         "node": ">= 12.13.0"
@@ -12199,58 +11842,17 @@
       }
     },
     "node_modules/streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "dependencies": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^10.0.0"
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/date-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-      "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/streamroller/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/streamroller/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12631,9 +12233,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "27.1.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
-      "integrity": "sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==",
+      "version": "27.1.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
+      "integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -12794,9 +12396,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13086,9 +12688,9 @@
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -13713,14 +13315,14 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.0.2.tgz",
-      "integrity": "sha512-Jt7iaBjoLGC5Nq4dHPTvTYnqPGkElFPBtTXTvBpTgatZApczyjI2plE0oG4GYWPp1suHIS/VdVDOMpPZjGVusg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.1.0.tgz",
+      "integrity": "sha512-x5L1knvA3isRWBRVQx+Q6D45pA9139a2aZQYpxkljMG0dj4UHZkCnsYWpnGalxPxASI7nrI0KedKfS2YeQ55cQ==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^16.0.0",
         "@commitlint/lint": "^16.0.0",
-        "@commitlint/load": "^16.0.0",
+        "@commitlint/load": "^16.1.0",
         "@commitlint/read": "^16.0.0",
         "@commitlint/types": "^16.0.0",
         "lodash": "^4.17.19",
@@ -13739,9 +13341,9 @@
       }
     },
     "@commitlint/config-validator": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.0.0.tgz",
-      "integrity": "sha512-i80DGlo1FeC5jZpuoNV9NIjQN/m2dDV3jYGWg+1Wr+KldptkUHXj+6GY1Akll66lJ3D8s6aUGi3comPLHPtWHg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-16.1.0.tgz",
+      "integrity": "sha512-2cHeZPNTuf1JWbMqyA46MkExor5HMSgv8JrdmzEakUbJHUreh35/wN00FJf57qGs134exQW2thiSQ1IJUsVx2Q==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^16.0.0",
@@ -13797,14 +13399,14 @@
       }
     },
     "@commitlint/load": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.0.0.tgz",
-      "integrity": "sha512-7WhrGCkP6K/XfjBBguLkkI2XUdiiIyMGlNsSoSqgRNiD352EiffhFEApMy1/XOU+viwBBm/On0n5p0NC7e9/4A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-16.1.0.tgz",
+      "integrity": "sha512-MtlEhKjP8jAF85jjX4mw8DUUwCxKsCgAc865hhpnwxjrfBcmGP7Up2AFE/M3ZMGDmSl1X1TMybQk/zohj8Cqdg==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/config-validator": "^16.1.0",
         "@commitlint/execute-rule": "^16.0.0",
-        "@commitlint/resolve-extends": "^16.0.0",
+        "@commitlint/resolve-extends": "^16.1.0",
         "@commitlint/types": "^16.0.0",
         "chalk": "^4.0.0",
         "cosmiconfig": "^7.0.0",
@@ -13844,12 +13446,12 @@
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.0.0.tgz",
-      "integrity": "sha512-Z/w9MAQUcxeawpCLtjmkVNXAXOmB2nhW+LYmHEZcx9O6UTauF/1+uuZ2/r0MtzTe1qw2JD+1QHVhEWYHVPlkdA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-16.1.0.tgz",
+      "integrity": "sha512-8182s6AFoUFX6+FT1PgQDt15nO2ogdR/EN8SYVAdhNXw1rLz8kT5saB/ICw567GuRAUgFTUMGCXy3ctMOXPEDg==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^16.0.0",
+        "@commitlint/config-validator": "^16.1.0",
         "@commitlint/types": "^16.0.0",
         "import-fresh": "^3.0.0",
         "lodash": "^4.17.19",
@@ -14465,9 +14067,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
+      "integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
@@ -14477,7 +14079,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -14653,10 +14255,19 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
+    "@types/mock-fs": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+      "integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "version": "17.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -14705,14 +14316,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
-      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
+      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/type-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/type-utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -14721,67 +14332,53 @@
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
-      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      }
-    },
     "@typescript-eslint/parser": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
-      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
+      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.9.1",
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/typescript-estree": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/typescript-estree": "5.10.1",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
-      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
+      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1"
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/visitor-keys": "5.10.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
-      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
+      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/utils": "5.10.1",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
-      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
+      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
-      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
+      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
-        "@typescript-eslint/visitor-keys": "5.9.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/visitor-keys": "5.10.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -14789,13 +14386,27 @@
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
-      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+    "@typescript-eslint/utils": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
+      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.1",
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.10.1",
+        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/typescript-estree": "5.10.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
+      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.10.1",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -14878,12 +14489,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -15208,9 +14813,9 @@
       "dev": true
     },
     "cdk8s": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.10.tgz",
-      "integrity": "sha512-MfFlhX31ysw8zUtGXIvoRjh20v+KVwAHHXaRtMdtYcrxVzwvgtLB2mGvhHoqvowhStDWX6rTKCniG8QirCqkeA==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.21.tgz",
+      "integrity": "sha512-+R6n0k7i3YSZIKKyv2rhGuTJrhg7SUF6Ursvgp6mWYbDYTYO3yoZbhvOsoDVv/tXG8y4zC4RVEDffAcg8Hr8kg==",
       "dev": true,
       "requires": {
         "fast-json-patch": "^2.2.1",
@@ -15246,23 +14851,23 @@
       }
     },
     "cdk8s-cli": {
-      "version": "1.0.77",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.77.tgz",
-      "integrity": "sha512-v/4VymNP23+z/cWIKvUdmyNd8OqcXmD9k3MK4OxiUT4EMocoGmcXT72zJ1T15jDONtEw1cEJ0Y+nHSB9RNoOXg==",
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.83.tgz",
+      "integrity": "sha512-Iq+HoB3QeuEFMjOWZs/oTrNmsQ4Xqin1ukIu0j4RsqJ+YF6x1v+y8wro4goL5EkhaE7+CNbkSNbOa3KfnlFivg==",
       "dev": true,
       "requires": {
         "@types/node": "^12.13.0",
-        "ajv": "^8.8.2",
-        "cdk8s": "^1.4.0",
-        "cdk8s-plus-22": "^1.0.0-beta.85",
+        "ajv": "^8.9.0",
+        "cdk8s": "^1.4.10",
+        "cdk8s-plus-22": "^1.0.0-beta.96",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.187",
+        "constructs": "^3.3.197",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.444",
-        "json2jsii": "^0.2.104",
-        "sscaff": "^1.2.170",
+        "jsii-srcmak": "^0.1.454",
+        "json2jsii": "^0.2.114",
+        "sscaff": "^1.2.180",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -15274,9 +14879,9 @@
           "dev": true
         },
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -15292,9 +14897,9 @@
           "dev": true
         },
         "cdk8s": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.0.tgz",
-          "integrity": "sha512-thdjQcCcDKN7flQiDuQycD+lhKoQxTSVxw231d8ibMyKrZTzVAJhBvHqVnx3nN+buPdEfW+epGi3ISKmTT8hLw==",
+          "version": "1.4.12",
+          "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.12.tgz",
+          "integrity": "sha512-RZO4LA78osAHNiy1jAU+BeXbhNJUCt+MGPoUuDztJcn7f7OlbnSB67gviUUN2hLiJZYRp4xI/3UfB1J+mB9JdA==",
           "dev": true,
           "requires": {
             "fast-json-patch": "^2.2.1",
@@ -15330,9 +14935,9 @@
           }
         },
         "cdk8s-plus-22": {
-          "version": "1.0.0-beta.85",
-          "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.85.tgz",
-          "integrity": "sha512-FV/7/MQX3cAUiHRxJ+fTgMPprGEjFrBBU1CW7N0sRiCMvSiK8RKTBFw5AtNAUsPbTH70wKa1e2eu90HOXNBfDw==",
+          "version": "1.0.0-beta.98",
+          "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.98.tgz",
+          "integrity": "sha512-bbWYZIybpT8RsSOSPLAKVUEtPGhyQJGUQluvQxjVWFhricHBEorMu92HeYbdw10pBEFxiB2MFsVIXO/90pk6gQ==",
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -15379,9 +14984,9 @@
           }
         },
         "constructs": {
-          "version": "3.3.187",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.187.tgz",
-          "integrity": "sha512-0Y2R9cTV7+ASjPpFkOYCb3cA7BJRM1OVVwJfZCEUa+Nxpq7EK9K9hoz/8FuvQBVQV3hCu+VisEC5iDcM/Dg2qw==",
+          "version": "3.3.199",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.199.tgz",
+          "integrity": "sha512-BKkU/yKQGwauX9lQR9jhw13l5vch3g9tgvUQyoKDoKPJp7+x8OhXmHmI+OZInonGAWz1g8BzKDtVS+Mj7nIGag==",
           "dev": true
         },
         "decamelize": {
@@ -15729,9 +15334,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.33.tgz",
-      "integrity": "sha512-1lyxVYjD2yNSlDMryiktmgv/fzN+ykPqEYD5UJKdGerbwFjUd+LTl+rNiGqxob9POPVt49Ez0FXnm0/di6LQng==",
+      "version": "10.0.44",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.44.tgz",
+      "integrity": "sha512-DNcxbAEtJHCUTwDijBlRDfMBAQUdfM+9Yprx3lJcYpOL9+DfuORB9fK9nKCQ3igmN/kv+I1hVg2Lqe+aVl/W5A==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -15841,9 +15446,9 @@
       }
     },
     "cosmiconfig-typescript-loader": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.3.tgz",
-      "integrity": "sha512-ARo21VjxdacJUcHxgVMEYNIoVPYiuKOEwWBIYej4M22+pEbe3LzKgmht2UPM+0u7/T/KnZf2r/5IzHv2Nwz+/w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.4.tgz",
+      "integrity": "sha512-ulv2dvwurP/MZAIthXm69bO7EzzIUThZ6RJ1qXhdlXM6to3F+IKBL/17EnhYSG52A5N1KcAUu66vSG/3/77KrA==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7",
@@ -15914,9 +15519,9 @@
       }
     },
     "date-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
+      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
       "dev": true
     },
     "dateformat": {
@@ -16143,6 +15748,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-13.0.1.tgz",
+      "integrity": "sha512-u3KAkK+VHk01+D7V6SFtSJl2JScX1Yi4anKsKXS4oT8s8LnL5xgJe7XFAZ1bSsOfAmxU54OwOuhaLv3v70oXgw=="
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -16207,15 +15817,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
     },
     "entities": {
       "version": "2.0.3",
@@ -16371,9 +15972,9 @@
       }
     },
     "eslint": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-      "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
+      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",
@@ -16383,11 +15984,10 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
-        "enquirer": "^2.3.5",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.0",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.1.0",
+        "eslint-visitor-keys": "^3.2.0",
         "espree": "^9.3.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
@@ -16396,7 +15996,7 @@
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.6.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
@@ -16407,9 +16007,7 @@
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "progress": "^2.0.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.2.1",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0",
@@ -16431,12 +16029,6 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
         }
       }
     },
@@ -16448,12 +16040,12 @@
       "requires": {}
     },
     "eslint-plugin-jest": {
-      "version": "25.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.3.4.tgz",
-      "integrity": "sha512-CCnwG71wvabmwq/qkz0HWIqBHQxw6pXB1uqt24dxqJ9WB34pVg49bL1sjXphlJHgTMWGhBjN1PicdyxDxrfP5A==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz",
+      "integrity": "sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "^5.0.0"
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-scope": {
@@ -16484,9 +16076,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
       "dev": true
     },
     "espree": {
@@ -18320,9 +17912,9 @@
       }
     },
     "jsii-srcmak": {
-      "version": "0.1.444",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.444.tgz",
-      "integrity": "sha512-49yN6OSHwC1waMVtT+JhkU/hX0j+/dQFJMOksyxyH7y95SvMAICfCWmdgXBNg7p0/j5XkCKMfeSsRwnp7+K2Lg==",
+      "version": "0.1.456",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.456.tgz",
+      "integrity": "sha512-xvfSOidghzTr2rj63oEVujk6/0fksqA+YmakFTZxmaX1bFJHGLkEzGiS3y/f3v4Tl1+hKgXxakWYx0tzL+mNQQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^9.1.0",
@@ -18489,9 +18081,9 @@
       "dev": true
     },
     "json2jsii": {
-      "version": "0.2.104",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.104.tgz",
-      "integrity": "sha512-I1UranAsUn4otinldDvdghKOvd5Q9YD+Q9FgUD0zR/zG+F6G3PUqbZoi6RQRdu2g5nFxV7KfSkF041C8EPR+Yw==",
+      "version": "0.2.116",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.2.116.tgz",
+      "integrity": "sha512-ffc4HhaYRnY1s1kfAKRJAobWg+v9OLu9pYEFRKzWgfuLLyOjZTcu/MZMWLOYribm4vIbA2lJQInlipeKWKq2hg==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -18581,9 +18173,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "12.1.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
-      "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.1.tgz",
+      "integrity": "sha512-Ocht/eT+4/siWOZDJpNUKcKX2UeWW/pDbohJ4gRsrafAjBi79JK8kiNVk2ciIVNKdw0Q4ABptl2nr6uQAlRImw==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
@@ -18592,10 +18184,10 @@
         "debug": "^4.3.3",
         "execa": "^5.1.1",
         "lilconfig": "2.0.4",
-        "listr2": "^3.13.5",
+        "listr2": "^4.0.1",
         "micromatch": "^4.0.4",
         "normalize-path": "^3.0.0",
-        "object-inspect": "^1.11.1",
+        "object-inspect": "^1.12.0",
         "string-argv": "^0.3.1",
         "supports-color": "^9.2.1",
         "yaml": "^1.10.2"
@@ -18616,9 +18208,9 @@
       }
     },
     "listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.1.tgz",
+      "integrity": "sha512-D65Nl+zyYHL2jQBGmxtH/pU8koPZo5C8iCNE8EoB04RwPgQG1wuaKwVbeZv9LJpiH4Nxs0FCp+nNcG8OqpniiA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
@@ -18626,7 +18218,7 @@
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
+        "rxjs": "^7.5.2",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -18793,24 +18385,16 @@
       }
     },
     "log4js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
+      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",
       "dev": true,
       "requires": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
-      },
-      "dependencies": {
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-          "dev": true
-        }
+        "date-format": "^4.0.3",
+        "debug": "^4.3.3",
+        "flatted": "^3.2.4",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.0.2"
       }
     },
     "lower-case": {
@@ -18870,23 +18454,46 @@
       "dev": true
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
-      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.0.0.tgz",
+      "integrity": "sha512-26604GmGmW63ElxcXpE2xfMdbtgD/qiwIqOh/+5+uPe6NVU4bU433+wvPTfq6NZcGr16KWqwu/dzsKxg3IL2Xw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
+        "chalk": "^5.0.0",
         "cli-table3": "^0.6.0",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+          "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^1.0.2"
+          }
+        },
+        "chalk": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+          "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
+        }
       }
     },
     "mdurl": {
@@ -19007,6 +18614,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
+    "mock-fs": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
       "dev": true
     },
     "modify-values": {
@@ -19134,9 +18747,9 @@
       "dev": true
     },
     "npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.3.2.tgz",
+      "integrity": "sha512-xZAC9GpWNOyiS1TtBqBy0HJpjIVI8zsVXEOEwcmgqYFtqOy7sXUL0ByOrkhfcGmf+akSXz3uOxLYB8aLlYivQQ==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "*",
@@ -19194,6 +18807,7 @@
         "opener": "*",
         "pacote": "*",
         "parse-conflict-json": "*",
+        "proc-log": "*",
         "qrcode-terminal": "*",
         "read": "*",
         "read-package-json": "*",
@@ -19222,20 +18836,20 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "2.9.0",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@isaacs/string-locale-compare": "^1.0.1",
+            "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^1.0.2",
-            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/metavuln-calculator": "^2.0.0",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^1.8.2",
-            "bin-links": "^2.2.1",
+            "@npmcli/run-script": "^2.0.0",
+            "bin-links": "^3.0.0",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
@@ -19246,8 +18860,8 @@
             "npm-package-arg": "^8.1.5",
             "npm-pick-manifest": "^6.1.0",
             "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.3.5",
-            "parse-conflict-json": "^1.1.1",
+            "pacote": "^12.0.2",
+            "parse-conflict-json": "^2.0.1",
             "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
@@ -19261,12 +18875,12 @@
           }
         },
         "@npmcli/ci-detect": {
-          "version": "1.3.0",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19319,7 +18933,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.4",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19330,12 +18944,13 @@
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "1.1.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "cacache": "^15.0.5",
-            "pacote": "^11.1.11",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^12.0.0",
             "semver": "^7.3.2"
           }
         },
@@ -19354,7 +18969,7 @@
           "dev": true
         },
         "@npmcli/node-gyp": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
@@ -19375,13 +18990,13 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.6",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "node-gyp": "^7.1.0",
+            "node-gyp": "^8.2.0",
             "read-package-json-fast": "^2.0.1"
           }
         },
@@ -19404,7 +19019,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.1.4",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19420,17 +19035,6 @@
           "requires": {
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
-          }
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -19467,7 +19071,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.6",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19480,58 +19084,22 @@
           "bundled": true,
           "dev": true
         },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.11.0",
-          "bundled": true,
-          "dev": true
-        },
         "balanced-match": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
         "bin-links": {
-          "version": "2.2.1",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "cmd-shim": "^4.0.1",
-            "mkdirp": "^1.0.3",
+            "mkdirp-infer-owner": "^2.0.0",
             "npm-normalize-package-bin": "^1.0.0",
             "read-cmd-shim": "^2.0.0",
             "rimraf": "^3.0.0",
-            "write-file-atomic": "^3.0.3"
+            "write-file-atomic": "^4.0.0"
           }
         },
         "binary-extensions": {
@@ -19578,11 +19146,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.2",
           "bundled": true,
@@ -19611,12 +19174,42 @@
           "dev": true
         },
         "cli-columns": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         },
         "cli-table3": {
@@ -19672,11 +19265,6 @@
             "mkdirp-infer-owner": "^2.0.0"
           }
         },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "color-convert": {
           "version": "2.0.1",
           "bundled": true,
@@ -19710,14 +19298,6 @@
             "wcwidth": "^1.0.0"
           }
         },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
         "common-ancestor-path": {
           "version": "1.0.1",
           "bundled": true,
@@ -19732,19 +19312,6 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
         },
         "debug": {
           "version": "4.3.2",
@@ -19774,11 +19341,6 @@
             "clone": "^1.0.2"
           }
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
@@ -19802,15 +19364,6 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -19836,33 +19389,8 @@
           "bundled": true,
           "dev": true
         },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
           "bundled": true,
           "dev": true
         },
@@ -19885,27 +19413,49 @@
           "dev": true
         },
         "gauge": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
             "has-unicode": "^2.0.1",
-            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1 || ^2.0.0",
-            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
             "wide-align": "^1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         },
         "glob": {
@@ -19926,20 +19476,6 @@
           "bundled": true,
           "dev": true
         },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
         "has": {
           "version": "1.0.3",
           "bundled": true,
@@ -19959,7 +19495,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19979,16 +19515,6 @@
             "@tootallnate/once": "1",
             "agent-base": "6",
             "debug": "4"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -20018,7 +19544,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.4",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20092,7 +19618,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.7.0",
+          "version": "2.8.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20119,28 +19645,8 @@
           "bundled": true,
           "dev": true
         },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
           "bundled": true,
           "dev": true
         },
@@ -20149,39 +19655,23 @@
           "bundled": true,
           "dev": true
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "jsonparse": {
           "version": "1.3.1",
           "bundled": true,
           "dev": true
         },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
         "just-diff": {
-          "version": "3.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "3.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "4.0.3",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20192,7 +19682,7 @@
           }
         },
         "libnpmdiff": {
-          "version": "2.0.4",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20202,22 +19692,22 @@
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
             "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "pacote": "^12.0.0",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "2.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.3.0",
+            "@npmcli/arborist": "^4.0.0",
             "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/run-script": "^2.0.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-package-arg": "^8.1.2",
-            "pacote": "^11.3.1",
+            "pacote": "^12.0.0",
             "proc-log": "^1.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
@@ -20225,15 +19715,15 @@
           }
         },
         "libnpmfund": {
-          "version": "1.1.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.5.0"
+            "@npmcli/arborist": "^4.0.0"
           }
         },
         "libnpmhook": {
-          "version": "6.0.3",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20242,7 +19732,7 @@
           }
         },
         "libnpmorg": {
-          "version": "2.0.3",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20251,17 +19741,17 @@
           }
         },
         "libnpmpack": {
-          "version": "2.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/run-script": "^1.8.3",
+            "@npmcli/run-script": "^2.0.0",
             "npm-package-arg": "^8.1.0",
-            "pacote": "^11.2.6"
+            "pacote": "^12.0.0"
           }
         },
         "libnpmpublish": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20273,7 +19763,7 @@
           }
         },
         "libnpmsearch": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20281,7 +19771,7 @@
           }
         },
         "libnpmteam": {
-          "version": "2.0.4",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20290,12 +19780,12 @@
           }
         },
         "libnpmversion": {
-          "version": "1.2.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/run-script": "^2.0.0",
             "json-parse-even-better-errors": "^2.3.1",
             "semver": "^7.3.5",
             "stringify-package": "^1.0.1"
@@ -20332,19 +19822,6 @@
             "ssri": "^8.0.0"
           }
         },
-        "mime-db": {
-          "version": "1.49.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.32",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.49.0"
-          }
-        },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
@@ -20354,7 +19831,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.5",
+          "version": "3.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20453,71 +19930,20 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "7.1.2",
+          "version": "8.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
+            "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^9.1.0",
             "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
+            "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.2",
             "which": "^2.0.2"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
           }
         },
         "nopt": {
@@ -20579,12 +20005,12 @@
           }
         },
         "npm-packlist": {
-          "version": "2.2.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.6",
-            "ignore-walk": "^3.0.3",
+            "ignore-walk": "^4.0.1",
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -20627,36 +20053,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "5.0.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "are-we-there-yet": "^2.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^3.0.0",
+            "gauge": "^4.0.0",
             "set-blocking": "^2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
           }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true,
-          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -20685,14 +20090,14 @@
           }
         },
         "pacote": {
-          "version": "11.3.5",
+          "version": "12.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^1.8.2",
+            "@npmcli/run-script": "^2.0.0",
             "cacache": "^15.0.5",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
@@ -20700,7 +20105,7 @@
             "minipass": "^3.1.3",
             "mkdirp": "^1.0.3",
             "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^2.1.4",
+            "npm-packlist": "^3.0.0",
             "npm-pick-manifest": "^6.0.0",
             "npm-registry-fetch": "^11.0.0",
             "promise-retry": "^2.0.1",
@@ -20711,22 +20116,17 @@
           }
         },
         "parse-conflict-json": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "just-diff": "^3.0.1",
-            "just-diff-apply": "^3.0.0"
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
+            "just-diff-apply": "^4.0.1"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
           "bundled": true,
           "dev": true
         },
@@ -20767,23 +20167,8 @@
             "read": "1"
           }
         },
-        "psl": {
-          "version": "1.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
           "bundled": true,
           "dev": true
         },
@@ -20841,54 +20226,6 @@
             "once": "^1.3.0"
           }
         },
-        "request": {
-          "version": "2.88.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-              }
-            }
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -20910,7 +20247,8 @@
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "7.3.5",
@@ -20926,7 +20264,7 @@
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.6",
           "bundled": true,
           "dev": true
         },
@@ -20981,22 +20319,6 @@
           "version": "3.0.10",
           "bundled": true,
           "dev": true
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
         },
         "ssri": {
           "version": "8.0.1",
@@ -21087,26 +20409,10 @@
           "bundled": true,
           "dev": true
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
+        "typedarray-to-buffer": {
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
-        },
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
         },
         "unique-filename": {
           "version": "1.1.1",
@@ -21124,21 +20430,8 @@
             "imurmurhash": "^0.1.4"
           }
         },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -21157,16 +20450,6 @@
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
           }
         },
         "walk-up-path": {
@@ -21204,14 +20487,14 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "3.0.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
             "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
+            "typedarray-to-buffer": "^4.0.0"
           }
         },
         "yallist": {
@@ -21602,12 +20885,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -21805,9 +21082,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -21965,15 +21242,15 @@
       }
     },
     "semantic-release": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.1.tgz",
-      "integrity": "sha512-xTdKCaEnCzHr+Fqyhg/5I8P9pvY9z7WHa8TFCYIwcdPbuzAtQShOTzw3VNPsqBT+Yq1kFyBQFBKBYkGOlqWmfA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
         "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
@@ -21987,8 +21264,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -22247,6 +21524,21 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -22332,9 +21624,9 @@
       "dev": true
     },
     "sscaff": {
-      "version": "1.2.170",
-      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.170.tgz",
-      "integrity": "sha512-h+P/7sNWh9hzKGbymcbuweb0t3VusiCEagUN+Rlk/qUR8W0fzQE80xMpKYe4qlQUHItWMi5JnYhM0KbM/IASNQ==",
+      "version": "1.2.182",
+      "resolved": "https://registry.npmjs.org/sscaff/-/sscaff-1.2.182.tgz",
+      "integrity": "sha512-b1zHT4Xfl4pAxc+wcUSmBeijtn6aveO4+3oGRLrNCrHvrh3RsU1kTrkkVBUhYsYDafxW8GeSOJ/rdLmiT3xa4A==",
       "dev": true
     },
     "stack-utils": {
@@ -22397,48 +21689,14 @@
       }
     },
     "streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
+      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
       "dev": true,
       "requires": {
-        "date-format": "^2.1.0",
+        "date-format": "^4.0.3",
         "debug": "^4.1.1",
-        "fs-extra": "^8.1.0"
-      },
-      "dependencies": {
-        "date-format": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
+        "fs-extra": "^10.0.0"
       }
     },
     "string_decoder": {
@@ -22721,9 +21979,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "27.1.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
-      "integrity": "sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==",
+      "version": "27.1.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
+      "integrity": "sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -22818,9 +22076,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {
@@ -23051,9 +22309,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "talis-cdk8s-constructs",
       "version": "0.1.0",
       "dependencies": {
-        "dotenv": "^13.0.1",
+        "dotenv": "^14.3.2",
         "sort-keys": "^4.2.0"
       },
       "devDependencies": {
@@ -20,9 +20,9 @@
         "@types/node": "^17.0.12",
         "@typescript-eslint/eslint-plugin": "^5.10.1",
         "@typescript-eslint/parser": "^5.10.1",
-        "cdk8s": "^2.1.21",
-        "cdk8s-cli": "^1.0.83",
-        "constructs": "^10.0.44",
+        "cdk8s": "^2.1.22",
+        "cdk8s-cli": "^1.0.85",
+        "constructs": "^10.0.45",
         "eslint": "^8.7.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jest": "^26.0.0",
@@ -39,8 +39,8 @@
         "typescript": "^4.5.5"
       },
       "peerDependencies": {
-        "cdk8s": "^2.1.21",
-        "constructs": "^10.0.44"
+        "cdk8s": "^2.1.22",
+        "constructs": "^10.0.45"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2550,9 +2550,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.21.tgz",
-      "integrity": "sha512-+R6n0k7i3YSZIKKyv2rhGuTJrhg7SUF6Ursvgp6mWYbDYTYO3yoZbhvOsoDVv/tXG8y4zC4RVEDffAcg8Hr8kg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.22.tgz",
+      "integrity": "sha512-enzeWQ8PaH9lmNW0d4loSChJfdKcGZlfmy08Wt0Opx+Ky46ZQTMWLaCLa2V81qXKukapeRduVtc51D8WFyRs/Q==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -2572,23 +2572,23 @@
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.83.tgz",
-      "integrity": "sha512-Iq+HoB3QeuEFMjOWZs/oTrNmsQ4Xqin1ukIu0j4RsqJ+YF6x1v+y8wro4goL5EkhaE7+CNbkSNbOa3KfnlFivg==",
+      "version": "1.0.85",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.85.tgz",
+      "integrity": "sha512-VRmVD/tBo/5RCqjTBMeScMLCAY1Z+Iu3hm88yw/rcTKJrdfWlfPEROAKJiLNfBUppfZDgkOVimGXeYIYM1MiSQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "^12.13.0",
         "ajv": "^8.9.0",
-        "cdk8s": "^1.4.10",
-        "cdk8s-plus-22": "^1.0.0-beta.96",
+        "cdk8s": "^1.4.13",
+        "cdk8s-plus-22": "^1.0.0-beta.98",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.197",
+        "constructs": "^3.3.199",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.454",
-        "json2jsii": "^0.2.114",
-        "sscaff": "^1.2.180",
+        "jsii-srcmak": "^0.1.456",
+        "json2jsii": "^0.2.116",
+        "sscaff": "^1.2.182",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/cdk8s-cli/node_modules/cdk8s": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.12.tgz",
-      "integrity": "sha512-RZO4LA78osAHNiy1jAU+BeXbhNJUCt+MGPoUuDztJcn7f7OlbnSB67gviUUN2hLiJZYRp4xI/3UfB1J+mB9JdA==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.13.tgz",
+      "integrity": "sha512-JijJ7DwaiCm2kDLZTVQ9dilx8rEwuZk7ZmqO+8nF81UIdBvz14L+wljW9pUj/HuvXO40rLWa1+R94IgIv4JnPA==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -2649,7 +2649,7 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "constructs": "^3.3.198"
+        "constructs": "^3.3.199"
       }
     },
     "node_modules/cdk8s-cli/node_modules/cdk8s-plus-22": {
@@ -3266,9 +3266,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.0.44",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.44.tgz",
-      "integrity": "sha512-DNcxbAEtJHCUTwDijBlRDfMBAQUdfM+9Yprx3lJcYpOL9+DfuORB9fK9nKCQ3igmN/kv+I1hVg2Lqe+aVl/W5A==",
+      "version": "10.0.45",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.45.tgz",
+      "integrity": "sha512-QZkRmlLh7lx/pn5yj1nc7EwWrfZ99bl+fiNY8J1UtKwGb4iq/oZx9dmnsmjSlUW1iU2mZ5/5VmFHjF0z9YvvNQ==",
       "dev": true,
       "engines": {
         "node": ">= 12.7.0"
@@ -3809,9 +3809,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-13.0.1.tgz",
-      "integrity": "sha512-u3KAkK+VHk01+D7V6SFtSJl2JScX1Yi4anKsKXS4oT8s8LnL5xgJe7XFAZ1bSsOfAmxU54OwOuhaLv3v70oXgw==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
       "engines": {
         "node": ">=12"
       }
@@ -7683,15 +7683,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -14813,9 +14821,9 @@
       "dev": true
     },
     "cdk8s": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.21.tgz",
-      "integrity": "sha512-+R6n0k7i3YSZIKKyv2rhGuTJrhg7SUF6Ursvgp6mWYbDYTYO3yoZbhvOsoDVv/tXG8y4zC4RVEDffAcg8Hr8kg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.1.22.tgz",
+      "integrity": "sha512-enzeWQ8PaH9lmNW0d4loSChJfdKcGZlfmy08Wt0Opx+Ky46ZQTMWLaCLa2V81qXKukapeRduVtc51D8WFyRs/Q==",
       "dev": true,
       "requires": {
         "fast-json-patch": "^2.2.1",
@@ -14851,23 +14859,23 @@
       }
     },
     "cdk8s-cli": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.83.tgz",
-      "integrity": "sha512-Iq+HoB3QeuEFMjOWZs/oTrNmsQ4Xqin1ukIu0j4RsqJ+YF6x1v+y8wro4goL5EkhaE7+CNbkSNbOa3KfnlFivg==",
+      "version": "1.0.85",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-1.0.85.tgz",
+      "integrity": "sha512-VRmVD/tBo/5RCqjTBMeScMLCAY1Z+Iu3hm88yw/rcTKJrdfWlfPEROAKJiLNfBUppfZDgkOVimGXeYIYM1MiSQ==",
       "dev": true,
       "requires": {
         "@types/node": "^12.13.0",
         "ajv": "^8.9.0",
-        "cdk8s": "^1.4.10",
-        "cdk8s-plus-22": "^1.0.0-beta.96",
+        "cdk8s": "^1.4.13",
+        "cdk8s-plus-22": "^1.0.0-beta.98",
         "codemaker": "^1.52.1",
         "colors": "1.4.0",
-        "constructs": "^3.3.197",
+        "constructs": "^3.3.199",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.52.1",
-        "jsii-srcmak": "^0.1.454",
-        "json2jsii": "^0.2.114",
-        "sscaff": "^1.2.180",
+        "jsii-srcmak": "^0.1.456",
+        "json2jsii": "^0.2.116",
+        "sscaff": "^1.2.182",
         "yaml": "2.0.0-10",
         "yargs": "^15"
       },
@@ -14897,9 +14905,9 @@
           "dev": true
         },
         "cdk8s": {
-          "version": "1.4.12",
-          "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.12.tgz",
-          "integrity": "sha512-RZO4LA78osAHNiy1jAU+BeXbhNJUCt+MGPoUuDztJcn7f7OlbnSB67gviUUN2hLiJZYRp4xI/3UfB1J+mB9JdA==",
+          "version": "1.4.13",
+          "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-1.4.13.tgz",
+          "integrity": "sha512-JijJ7DwaiCm2kDLZTVQ9dilx8rEwuZk7ZmqO+8nF81UIdBvz14L+wljW9pUj/HuvXO40rLWa1+R94IgIv4JnPA==",
           "dev": true,
           "requires": {
             "fast-json-patch": "^2.2.1",
@@ -15334,9 +15342,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.0.44",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.44.tgz",
-      "integrity": "sha512-DNcxbAEtJHCUTwDijBlRDfMBAQUdfM+9Yprx3lJcYpOL9+DfuORB9fK9nKCQ3igmN/kv+I1hVg2Lqe+aVl/W5A==",
+      "version": "10.0.45",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.45.tgz",
+      "integrity": "sha512-QZkRmlLh7lx/pn5yj1nc7EwWrfZ99bl+fiNY8J1UtKwGb4iq/oZx9dmnsmjSlUW1iU2mZ5/5VmFHjF0z9YvvNQ==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -15749,9 +15757,9 @@
       }
     },
     "dotenv": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-13.0.1.tgz",
-      "integrity": "sha512-u3KAkK+VHk01+D7V6SFtSJl2JScX1Yi4anKsKXS4oT8s8LnL5xgJe7XFAZ1bSsOfAmxU54OwOuhaLv3v70oXgw=="
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ=="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -18678,9 +18686,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -24,32 +24,38 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "cdk8s": "^2.1.10",
-    "constructs": "^10.0.33"
+    "cdk8s": "^2.1.21",
+    "constructs": "^10.0.44"
+  },
+  "dependencies": {
+    "dotenv": "^13.0.1",
+    "sort-keys": "^4.2.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^16.0.2",
+    "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.178",
-    "@types/node": "^17.0.8",
-    "@typescript-eslint/eslint-plugin": "^5.9.1",
-    "@typescript-eslint/parser": "^5.9.1",
-    "cdk8s": "^2.1.10",
-    "cdk8s-cli": "^1.0.77",
-    "constructs": "^10.0.33",
-    "eslint": "^8.6.0",
+    "@types/mock-fs": "^4.13.1",
+    "@types/node": "^17.0.12",
+    "@typescript-eslint/eslint-plugin": "^5.10.1",
+    "@typescript-eslint/parser": "^5.10.1",
+    "cdk8s": "^2.1.21",
+    "cdk8s-cli": "^1.0.83",
+    "constructs": "^10.0.44",
+    "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-jest": "^25.3.4",
+    "eslint-plugin-jest": "^26.0.0",
     "husky": "^7.0.4",
     "jest": "^27.4.7",
     "jest-junit": "^13.0.0",
-    "lint-staged": "^12.1.7",
+    "lint-staged": "^12.3.1",
     "lodash": "^4.17.21",
+    "mock-fs": "^5.1.2",
     "prettier": "^2.5.1",
-    "semantic-release": "^18.0.1",
-    "ts-jest": "^27.1.2",
+    "semantic-release": "^19.0.2",
+    "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "cdk8s": "^2.1.21",
-    "constructs": "^10.0.44"
+    "cdk8s": "^2.1.22",
+    "constructs": "^10.0.45"
   },
   "dependencies": {
-    "dotenv": "^13.0.1",
+    "dotenv": "^14.3.2",
     "sort-keys": "^4.2.0"
   },
   "devDependencies": {
@@ -40,9 +40,9 @@
     "@types/node": "^17.0.12",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
-    "cdk8s": "^2.1.21",
-    "cdk8s-cli": "^1.0.83",
-    "constructs": "^10.0.44",
+    "cdk8s": "^2.1.22",
+    "cdk8s-cli": "^1.0.85",
+    "constructs": "^10.0.45",
     "eslint": "^8.7.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^26.0.0",

--- a/test/data/__snapshots__/config-map.test.ts.snap
+++ b/test/data/__snapshots__/config-map.test.ts.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfigMap Accessors Metadata getter 1`] = `
+ApiObjectMetadataDefinition {
+  "_additionalAttributes": Object {
+    "labels": Object {
+      "prunable": "true",
+      "test": "true",
+    },
+    "name": Lazy {
+      "producer": Object {
+        "produce": [Function],
+      },
+    },
+    "namespace": undefined,
+  },
+  "annotations": Object {},
+  "finalizers": Array [],
+  "labels": Object {
+    "prunable": "true",
+    "test": "true",
+  },
+  "name": Lazy {
+    "producer": Object {
+      "produce": [Function],
+    },
+  },
+  "namespace": undefined,
+  "ownerReferences": Array [],
+}
+`;
+
+exports[`ConfigMap Accessors Throws when trying to set binaryData key on data 1`] = `"ConfigMap key \\"test\\" is already used in binaryData"`;
+
+exports[`ConfigMap Accessors Throws when trying to set data key on binaryData 1`] = `"ConfigMap key \\"test\\" is already used in data"`;
+
+exports[`ConfigMap Loading files Setting value from binary file's contents 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "binaryData": Object {
+      "file.bin": "0101010",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-bmgdfkhtdc",
+    },
+  },
+]
+`;
+
+exports[`ConfigMap Loading files Setting value from binary file's contents with custom key 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "binaryData": Object {
+      "greeting.bin": "0101010",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-d6tg59df79",
+    },
+  },
+]
+`;
+
+exports[`ConfigMap Loading files Setting value from file's contents 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "file.txt": "hello world!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-9d44k9f5tb",
+    },
+  },
+]
+`;
+
+exports[`ConfigMap Loading files Setting value from file's contents with custom key 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "greeting.txt": "hello world!",
+    },
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-g88dtg6tg9",
+    },
+  },
+]
+`;
+
+exports[`ConfigMap Props ConfigMap from props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "binaryData": Object {
+      "bin": "010101",
+    },
+    "data": Object {
+      "foo": "bar",
+    },
+    "immutable": true,
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "annotations": Object {
+        "annotation": "test",
+      },
+      "labels": Object {
+        "label": "test",
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-8598d5k4th",
+    },
+  },
+]
+`;
+
+exports[`ConfigMap Props Empty ConfigMap 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-hfh6t42gd2",
+    },
+  },
+]
+`;

--- a/test/data/__snapshots__/secret.test.ts.snap
+++ b/test/data/__snapshots__/secret.test.ts.snap
@@ -5,14 +5,14 @@ Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
-      "test": "foo",
+      "test": "Zm9v",
     },
     "kind": "Secret",
     "metadata": Object {
       "labels": Object {
         "prunable": "true",
       },
-      "name": "test-c8eb60f8-b5htk5g56c",
+      "name": "test-c8eb60f8-77f7g47dgb",
     },
     "stringData": Object {
       "test": "bar",
@@ -51,73 +51,39 @@ ApiObjectMetadataDefinition {
 }
 `;
 
-exports[`Secret Loading files Setting value from binary file's contents with custom key 1`] = `
-Array [
-  Object {
-    "apiVersion": "v1",
-    "kind": "Secret",
-    "metadata": Object {
-      "labels": Object {
-        "prunable": "true",
-      },
-      "name": "test-c8eb60f8-58hg54cfmf",
-    },
-    "stringData": Object {
-      "greeting.txt": "hello",
-    },
-  },
-]
-`;
+exports[`Secret Accessors Throws when trying to set stringData key on data 1`] = `"Secret data key \\"test\\" is already used in stringData, which takes precedence"`;
 
-exports[`Secret Loading files Setting value from file's contents 1`] = `
+exports[`Secret Loading files Encoding data value from file's contents 1`] = `
 Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
-      "file.enc": "secret#!23",
+      "file.enc": "c2VjcmV0IyEyMw==",
     },
     "kind": "Secret",
     "metadata": Object {
       "labels": Object {
         "prunable": "true",
       },
-      "name": "test-c8eb60f8-f6kkddkdch",
+      "name": "test-c8eb60f8-g7hfd9465k",
     },
   },
 ]
 `;
 
-exports[`Secret Loading files Setting value from file's contents with custom key 1`] = `
+exports[`Secret Loading files Encoding data value from file's contents with custom key 1`] = `
 Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
-      "greeting.enc": "secret#!23",
+      "greeting.enc": "c2VjcmV0IyEyMw==",
     },
     "kind": "Secret",
     "metadata": Object {
       "labels": Object {
         "prunable": "true",
       },
-      "name": "test-c8eb60f8-cfbm75t2f8",
-    },
-  },
-]
-`;
-
-exports[`Secret Loading files Setting value from string file's contents 1`] = `
-Array [
-  Object {
-    "apiVersion": "v1",
-    "kind": "Secret",
-    "metadata": Object {
-      "labels": Object {
-        "prunable": "true",
-      },
-      "name": "test-c8eb60f8-g9t89kcg82",
-    },
-    "stringData": Object {
-      "file.txt": "hello",
+      "name": "test-c8eb60f8-hb7bh85tb5",
     },
   },
 ]
@@ -143,7 +109,7 @@ Array [
   Object {
     "apiVersion": "v1",
     "data": Object {
-      "foo": "secret#!23",
+      "foo": "c2VjcmV0IyEyMw==",
     },
     "immutable": true,
     "kind": "Secret",
@@ -155,10 +121,10 @@ Array [
         "label": "test",
         "prunable": "true",
       },
-      "name": "test-c8eb60f8-2ch5g74c84",
+      "name": "test-c8eb60f8-2f6d9fk5k8",
     },
     "stringData": Object {
-      "bin": "hello",
+      "bar": "hello",
     },
     "type": "Opaque",
   },

--- a/test/data/__snapshots__/secret.test.ts.snap
+++ b/test/data/__snapshots__/secret.test.ts.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Secret Accessors Allows to set data key on stringData 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "test": "foo",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-b5htk5g56c",
+    },
+    "stringData": Object {
+      "test": "bar",
+    },
+  },
+]
+`;
+
+exports[`Secret Accessors Metadata getter 1`] = `
+ApiObjectMetadataDefinition {
+  "_additionalAttributes": Object {
+    "labels": Object {
+      "prunable": "true",
+      "test": "true",
+    },
+    "name": Lazy {
+      "producer": Object {
+        "produce": [Function],
+      },
+    },
+    "namespace": undefined,
+  },
+  "annotations": Object {},
+  "finalizers": Array [],
+  "labels": Object {
+    "prunable": "true",
+    "test": "true",
+  },
+  "name": Lazy {
+    "producer": Object {
+      "produce": [Function],
+    },
+  },
+  "namespace": undefined,
+  "ownerReferences": Array [],
+}
+`;
+
+exports[`Secret Loading files Setting value from binary file's contents with custom key 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-58hg54cfmf",
+    },
+    "stringData": Object {
+      "greeting.txt": "hello",
+    },
+  },
+]
+`;
+
+exports[`Secret Loading files Setting value from file's contents 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "file.enc": "secret#!23",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-f6kkddkdch",
+    },
+  },
+]
+`;
+
+exports[`Secret Loading files Setting value from file's contents with custom key 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "greeting.enc": "secret#!23",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-cfbm75t2f8",
+    },
+  },
+]
+`;
+
+exports[`Secret Loading files Setting value from string file's contents 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-g9t89kcg82",
+    },
+    "stringData": Object {
+      "file.txt": "hello",
+    },
+  },
+]
+`;
+
+exports[`Secret Props Empty Secret 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-5m7k5t56kf",
+    },
+  },
+]
+`;
+
+exports[`Secret Props Secret from props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      "foo": "secret#!23",
+    },
+    "immutable": true,
+    "kind": "Secret",
+    "metadata": Object {
+      "annotations": Object {
+        "annotation": "test",
+      },
+      "labels": Object {
+        "label": "test",
+        "prunable": "true",
+      },
+      "name": "test-c8eb60f8-2ch5g74c84",
+    },
+    "stringData": Object {
+      "bin": "hello",
+    },
+    "type": "Opaque",
+  },
+]
+`;

--- a/test/data/config-map.test.ts
+++ b/test/data/config-map.test.ts
@@ -137,6 +137,24 @@ describe("ConfigMap", () => {
       expect(results[0].metadata.name).toBe("no-suffix");
     });
 
+    test("It includes prunable label with suffix hash enabled", () => {
+      const chart = makeChart();
+      new ConfigMap(chart, "test", { disableNameSuffixHash: false });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.labels).toHaveProperty("prunable");
+      expect(results[0].metadata.labels.prunable).toBe("true");
+    });
+
+    test("It does not include prunable label with suffix hash disabled", () => {
+      const chart = makeChart();
+      new ConfigMap(chart, "test", {
+        metadata: { labels: { test: "true" } },
+        disableNameSuffixHash: true,
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.labels).not.toHaveProperty("prunable");
+    });
+
     test("Can be referenced in other objects", () => {
       const chart = makeChart();
       const configMap = new ConfigMap(chart, "test", { data: { FOO: "foo" } });

--- a/test/data/config-map.test.ts
+++ b/test/data/config-map.test.ts
@@ -1,0 +1,279 @@
+import mockFs from "mock-fs";
+import { Lazy, Testing } from "cdk8s";
+import { ConfigMap } from "../../lib";
+import { KubePod } from "../../imports/k8s";
+
+function makeChart() {
+  const chart = Testing.chart();
+  // Just output node's id as the object's name
+  chart.generateObjectName = (obj) => {
+    return obj.node.id;
+  };
+  return chart;
+}
+
+describe("ConfigMap", () => {
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  describe("Props", () => {
+    test("Empty ConfigMap", () => {
+      const chart = Testing.chart();
+      new ConfigMap(chart, "test");
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("ConfigMap from props", () => {
+      const chart = Testing.chart();
+      new ConfigMap(chart, "test", {
+        data: {
+          foo: "bar",
+        },
+        binaryData: {
+          bin: "010101",
+        },
+        immutable: true,
+        disableNameSuffixHash: false,
+        metadata: {
+          annotations: {
+            annotation: "test",
+          },
+          labels: {
+            label: "test",
+          },
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Accessors", () => {
+    test("Name property is a lazy producer", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      expect(configMap.name).toBeInstanceOf(Lazy);
+    });
+
+    test("Metadata getter", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test", {
+        metadata: {
+          labels: { test: "true" },
+        },
+      });
+      expect(configMap.metadata).toMatchSnapshot();
+    });
+
+    test("Data getter", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test", { data: { foo: "bar" } });
+      expect(configMap.data).toEqual({ foo: "bar" });
+    });
+
+    test("Binary data getter", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test", {
+        binaryData: { foo: "bar" },
+      });
+      expect(configMap.binaryData).toEqual({ foo: "bar" });
+    });
+
+    test("Throws when trying to set data key on binaryData", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setData("test", "foo");
+      expect(() => {
+        configMap.setBinaryData("test", "bar");
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("Throws when trying to set binaryData key on data", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setBinaryData("test", "foo");
+      expect(() => {
+        configMap.setData("test", "bar");
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("Overriding keys", () => {
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test", {
+        data: {
+          UNTOUCHED: "yes",
+          OVERRIDDEN: "maybe?",
+        },
+      });
+      configMap.setData("OVERRIDDEN", "once");
+      mockFs({
+        ".env": "OVERRIDDEN=from file",
+      });
+      configMap.setFromEnvFile(".env");
+      configMap.setData("OVERRIDDEN", "final");
+      expect(configMap.data).toEqual({
+        UNTOUCHED: "yes",
+        OVERRIDDEN: "final",
+      });
+    });
+  });
+
+  describe("Name suffix hash", () => {
+    test("It includes suffix hash by default", () => {
+      const chart = makeChart();
+      new ConfigMap(chart, "test");
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("test-4t7k5tctth");
+    });
+
+    test("Suffix hash can be disabled", () => {
+      const chart = makeChart();
+      new ConfigMap(chart, "no-suffix", {
+        disableNameSuffixHash: true,
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("no-suffix");
+    });
+
+    test("Can be referenced in other objects", () => {
+      const chart = makeChart();
+      const configMap = new ConfigMap(chart, "test", { data: { FOO: "foo" } });
+      new KubePod(chart, "pod", {
+        spec: {
+          containers: [
+            {
+              name: "test",
+              envFrom: [{ configMapRef: { name: configMap.name } }],
+            },
+          ],
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("test-9g94h95f62");
+      expect(results[0].metadata.name).toBe(
+        results[1].spec.containers[0].envFrom[0].configMapRef.name
+      );
+    });
+
+    test("Can be referenced in other objects with suffix disabled", () => {
+      const chart = makeChart();
+      const configMap = new ConfigMap(chart, "no-suffix", {
+        disableNameSuffixHash: true,
+        data: { FOO: "foo" },
+      });
+      new KubePod(chart, "pod", {
+        spec: {
+          containers: [
+            {
+              name: "test",
+              envFrom: [{ configMapRef: { name: configMap.name } }],
+            },
+          ],
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("no-suffix");
+      expect(results[0].metadata.name).toBe(
+        results[1].spec.containers[0].envFrom[0].configMapRef.name
+      );
+    });
+  });
+
+  describe("Loading files", () => {
+    test("Setting value from file's contents", () => {
+      mockFs({
+        "path/to/file.txt": "hello world!",
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setFile("path/to/file.txt");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from file's contents with custom key", () => {
+      mockFs({
+        "path/to/file.txt": "hello world!",
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setFile("path/to/file.txt", "greeting.txt");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from binary file's contents", () => {
+      mockFs({
+        "path/to/file.bin": "0101010",
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setBinaryFile("path/to/file.bin");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from binary file's contents with custom key", () => {
+      mockFs({
+        "path/to/file.bin": "0101010",
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setBinaryFile("path/to/file.bin", "greeting.bin");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Loading data key/values from .env file", () => {
+      mockFs({
+        "values.env": [
+          "FOO=bar",
+          "# a comment = ignore",
+          "VAR_WITH_SPECIAL_CHARS=space slash/other@#1!=",
+          "SIGNLE_QUOTED='yes it is'",
+          'DOUBLE_QUOTED="this too"',
+        ].join("\n"),
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setFromEnvFile("values.env");
+      expect(configMap.data).toEqual({
+        DOUBLE_QUOTED: "this too",
+        FOO: "bar",
+        SIGNLE_QUOTED: "yes it is",
+        VAR_WITH_SPECIAL_CHARS: "space slash/other@#1!=",
+      });
+    });
+
+    test("Loading empty .env file", () => {
+      mockFs({
+        "values.env": ["# a comment = ignore"].join("\n"),
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test");
+      configMap.setFromEnvFile("values.env");
+      expect(configMap.data).toEqual({});
+    });
+
+    test("Loading .env files from props", () => {
+      mockFs({
+        "bar.env": "BAR=bar",
+        "foo.env": "FOO=foo",
+      });
+      const chart = Testing.chart();
+      const configMap = new ConfigMap(chart, "test", {
+        envFiles: ["bar.env", "foo.env"],
+      });
+      expect(configMap.data).toEqual({
+        BAR: "bar",
+        FOO: "foo",
+      });
+    });
+  });
+});

--- a/test/data/hash-util.test.ts
+++ b/test/data/hash-util.test.ts
@@ -1,0 +1,58 @@
+import { hashObject } from "../../lib/data/hash-util";
+
+describe("hash-util", () => {
+  describe("hashObject", () => {
+    test("Empty", () => {
+      const hash = hashObject({});
+      expect(hash).toBe("44hk6fmk55");
+    });
+
+    test("Hash length", () => {
+      const hash = hashObject({});
+      expect(hash).toHaveLength(10);
+    });
+
+    [
+      { aaa: "bbb" }, // sha256:a38adcf124cd0be76ebe34eccdec97ef81012a634aea2b891a03251cc2180883
+      { foo: "bar" }, // sha256:7a38bf81f383f69433ad6e900d35b3e2385593f76a7b7ab5d4355b8ba41ee24b
+      { xxx: "zzz" }, // sha256:577a8a86407078408b9d77e2df34073b6126be0b66321dbcc3db6462042785ba
+    ].forEach((object) => {
+      test("Hash never includes vowel-like characters", () => {
+        const hash = hashObject(object);
+        expect(hash).toMatch(/^[^013ae]+$/);
+      });
+    });
+
+    test("Same hash regardless of key order", () => {
+      const object1 = {
+        kind: "Thing",
+        name: "Test",
+      };
+      const object2 = {
+        name: "Test",
+        kind: "Thing",
+      };
+      // Objects have the same content but different JSON string
+      expect(JSON.stringify(object1)).not.toEqual(JSON.stringify(object2));
+      // Object should have the same hash
+      expect(hashObject(object1)).toStrictEqual(hashObject(object2));
+    });
+
+    test("Same hash regardless of nested key order", () => {
+      const object1 = {
+        kind: "Thing",
+        name: "Test",
+        data: { foo: "bar", fizz: "buzz" },
+      };
+      const object2 = {
+        kind: "Thing",
+        name: "Test",
+        data: { fizz: "buzz", foo: "bar" },
+      };
+      // Objects have the same content but different JSON string
+      expect(JSON.stringify(object1)).not.toEqual(JSON.stringify(object2));
+      // Object should have the same hash
+      expect(hashObject(object1)).toStrictEqual(hashObject(object2));
+    });
+  });
+});

--- a/test/data/secret.test.ts
+++ b/test/data/secret.test.ts
@@ -207,7 +207,7 @@ describe("Secret", () => {
         "values.env": [
           "FOO=bar",
           "# a comment = ignore",
-          "VAR_WITH_SPECIAL_CHARS=space slash/other@#1!=",
+          "VAR_WITH_SPECIAL_CHARS=#%/!*;:@&=+$,#",
           "SIGNLE_QUOTED='yes it is'",
           'DOUBLE_QUOTED="this too"',
         ].join("\n"),
@@ -219,7 +219,7 @@ describe("Secret", () => {
         DOUBLE_QUOTED: "this too",
         FOO: "bar",
         SIGNLE_QUOTED: "yes it is",
-        VAR_WITH_SPECIAL_CHARS: "space slash/other@#1!=",
+        VAR_WITH_SPECIAL_CHARS: "#%/!*;:@&=+$,#",
       });
     });
 

--- a/test/data/secret.test.ts
+++ b/test/data/secret.test.ts
@@ -1,0 +1,251 @@
+import mockFs from "mock-fs";
+import { Lazy, Testing } from "cdk8s";
+import { Secret } from "../../lib";
+import { KubePod } from "../../imports/k8s";
+
+function makeChart() {
+  const chart = Testing.chart();
+  // Just output node's id as the object's name
+  chart.generateObjectName = (obj) => {
+    return obj.node.id;
+  };
+  return chart;
+}
+
+describe("Secret", () => {
+  describe("Props", () => {
+    test("Empty Secret", () => {
+      const chart = Testing.chart();
+      new Secret(chart, "test");
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Secret from props", () => {
+      const chart = Testing.chart();
+      new Secret(chart, "test", {
+        data: {
+          foo: "secret#!23",
+        },
+        stringData: {
+          bin: "hello",
+        },
+        immutable: true,
+        type: "Opaque",
+        disableNameSuffixHash: false,
+        metadata: {
+          annotations: {
+            annotation: "test",
+          },
+          labels: {
+            label: "test",
+          },
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Accessors", () => {
+    test("Name property is a lazy producer", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      expect(secret.name).toBeInstanceOf(Lazy);
+    });
+
+    test("Metadata getter", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test", {
+        metadata: {
+          labels: { test: "true" },
+        },
+      });
+      expect(secret.metadata).toMatchSnapshot();
+    });
+
+    test("Data getter", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test", { data: { foo: "bar" } });
+      expect(secret.data).toEqual({ foo: "bar" });
+    });
+
+    test("Binary data getter", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test", {
+        stringData: { foo: "bar" },
+      });
+      expect(secret.stringData).toEqual({ foo: "bar" });
+    });
+
+    test("Allows to set data key on stringData", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setData("test", "foo");
+      secret.setStringData("test", "bar");
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Name suffix hash", () => {
+    test("It includes suffix hash by default", () => {
+      const chart = makeChart();
+      new Secret(chart, "test");
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("test-2c7fh268c4");
+    });
+
+    test("Suffix hash can be disabled", () => {
+      const chart = makeChart();
+      new Secret(chart, "no-suffix", {
+        disableNameSuffixHash: true,
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("no-suffix");
+    });
+
+    test("Can be referenced in other objects", () => {
+      const chart = makeChart();
+      const secret = new Secret(chart, "test", { data: { FOO: "foo" } });
+      new KubePod(chart, "pod", {
+        spec: {
+          containers: [
+            {
+              name: "test",
+              envFrom: [{ secretRef: { name: secret.name } }],
+            },
+          ],
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("test-cggk7gg52t");
+      expect(results[0].metadata.name).toBe(
+        results[1].spec.containers[0].envFrom[0].secretRef.name
+      );
+    });
+
+    test("Can be referenced in other objects with suffix disabled", () => {
+      const chart = makeChart();
+      const secret = new Secret(chart, "no-suffix", {
+        disableNameSuffixHash: true,
+        data: { FOO: "foo" },
+      });
+      new KubePod(chart, "pod", {
+        spec: {
+          containers: [
+            {
+              name: "test",
+              envFrom: [{ secretRef: { name: secret.name } }],
+            },
+          ],
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.name).toBe("no-suffix");
+      expect(results[0].metadata.name).toBe(
+        results[1].spec.containers[0].envFrom[0].secretRef.name
+      );
+    });
+  });
+
+  describe("Loading files", () => {
+    afterEach(() => {
+      mockFs.restore();
+    });
+
+    test("Setting value from file's contents", () => {
+      mockFs({
+        "path/to/file.enc": "secret#!23",
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setFile("path/to/file.enc");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from file's contents with custom key", () => {
+      mockFs({
+        "path/to/file.enc": "secret#!23",
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setFile("path/to/file.enc", "greeting.enc");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from string file's contents", () => {
+      mockFs({
+        "path/to/file.txt": "hello",
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setStringFile("path/to/file.txt");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Setting value from binary file's contents with custom key", () => {
+      mockFs({
+        "path/to/file.txt": "hello",
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setStringFile("path/to/file.txt", "greeting.txt");
+      const results = Testing.synth(chart);
+      mockFs.restore();
+      expect(results).toMatchSnapshot();
+    });
+
+    test("Loading data key/values from .env file", () => {
+      mockFs({
+        "values.env": [
+          "FOO=bar",
+          "# a comment = ignore",
+          "VAR_WITH_SPECIAL_CHARS=space slash/other@#1!=",
+          "SIGNLE_QUOTED='yes it is'",
+          'DOUBLE_QUOTED="this too"',
+        ].join("\n"),
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setFromEnvFile("values.env");
+      expect(secret.data).toEqual({
+        DOUBLE_QUOTED: "this too",
+        FOO: "bar",
+        SIGNLE_QUOTED: "yes it is",
+        VAR_WITH_SPECIAL_CHARS: "space slash/other@#1!=",
+      });
+    });
+
+    test("Loading empty .env file", () => {
+      mockFs({
+        "values.env": ["# a comment = ignore"].join("\n"),
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setFromEnvFile("values.env");
+      expect(secret.data).toEqual({});
+    });
+
+    test("Loading .env files from props", () => {
+      mockFs({
+        "bar.env": "BAR=bar",
+        "foo.env": "FOO=foo",
+      });
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test", {
+        envFiles: ["bar.env", "foo.env"],
+      });
+      expect(secret.data).toEqual({
+        BAR: "bar",
+        FOO: "foo",
+      });
+    });
+  });
+});

--- a/test/data/secret.test.ts
+++ b/test/data/secret.test.ts
@@ -128,6 +128,24 @@ describe("Secret", () => {
       expect(results[0].metadata.name).toBe("no-suffix");
     });
 
+    test("It includes prunable label with suffix hash enabled", () => {
+      const chart = makeChart();
+      new Secret(chart, "test", { disableNameSuffixHash: false });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.labels).toHaveProperty("prunable");
+      expect(results[0].metadata.labels.prunable).toBe("true");
+    });
+
+    test("It does not include prunable label with suffix hash disabled", () => {
+      const chart = makeChart();
+      new Secret(chart, "test", {
+        metadata: { labels: { test: "true" } },
+        disableNameSuffixHash: true,
+      });
+      const results = Testing.synth(chart);
+      expect(results[0].metadata.labels).not.toHaveProperty("prunable");
+    });
+
     test("Can be referenced in other objects", () => {
       const chart = makeChart();
       const secret = new Secret(chart, "test", { data: { FOO: "foo" } });


### PR DESCRIPTION
* https://github.com/talis/platform/issues/5343
* Can load values from `.env` files
* Both can append a hash of its own contents to its name the same way [`kustomize`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/generatoroptions/) does.
* Update advanced WebService example to include ConfigMap with an `.env` file.