### PR TITLE
fix: ensure container name is set and correct use of service label

### DIFF
--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -224,7 +224,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -311,7 +311,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-c-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -749,7 +749,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -1056,7 +1056,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-c-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -1494,7 +1494,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -1581,7 +1581,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-c-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -2018,7 +2018,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -2325,7 +2325,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-c-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -2762,7 +2762,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -2849,7 +2849,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         "alb.ingress.kubernetes.io/load-balancer-name": "example-web-c-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=web,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=web,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {

--- a/examples/background-worker/__snapshots__/chart.test.ts.snap
+++ b/examples/background-worker/__snapshots__/chart.test.ts.snap
@@ -93,7 +93,7 @@ Array [
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/ssl-redirect": "443",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=resque,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=resque,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -440,7 +440,7 @@ Array [
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/ssl-redirect": "443",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "service=example,instance=resque,environment=development",
+        "alb.ingress.kubernetes.io/tags": "service=example-development-local,instance=resque,environment=development",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {

--- a/examples/simple-web-service/__snapshots__/main.test.ts.snap
+++ b/examples/simple-web-service/__snapshots__/main.test.ts.snap
@@ -125,6 +125,7 @@ Array [
             Object {
               "image": "docker.io/bitnami/node-example:0.0.1",
               "imagePullPolicy": "IfNotPresent",
+              "name": "app",
               "ports": Array [
                 Object {
                   "containerPort": 3000,

--- a/lib/background-worker/background-worker.ts
+++ b/lib/background-worker/background-worker.ts
@@ -12,7 +12,7 @@ export class BackgroundWorker extends Construct {
     const hasProp = (key: string) =>
       Object.prototype.hasOwnProperty.call(props, key);
     const chart = Chart.of(this);
-    const app = chart.labels.app;
+    const app = chart.labels.app ?? props.selectorLabels?.app;
     const labels = {
       ...chart.labels,
       release: props.release,
@@ -20,7 +20,7 @@ export class BackgroundWorker extends Construct {
     const affinityFunc = props.makeAffinity ?? defaultAffinity;
 
     const selectorLabels: { [key: string]: string } = {
-      app,
+      app: app,
       role: "worker",
       instance: id,
       ...props.selectorLabels,
@@ -55,7 +55,7 @@ export class BackgroundWorker extends Construct {
             volumes: props.volumes,
             containers: [
               {
-                name: app,
+                name: props.containerName ?? app ?? "app",
                 image: props.image,
                 imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
                 workingDir: props.workingDir,

--- a/lib/common/container-props.ts
+++ b/lib/common/container-props.ts
@@ -9,6 +9,12 @@ import {
 } from "../../imports/k8s";
 
 export interface ContainerProps {
+  /**
+   * What name to give the application container
+   * @default set from the "app" label
+   */
+  readonly containerName?: string;
+
   /** The Docker image to use. */
   readonly image: string;
 

--- a/test/background-worker/__snapshots__/background-worker.test.ts.snap
+++ b/test/background-worker/__snapshots__/background-worker.test.ts.snap
@@ -278,6 +278,7 @@ Array [
             Object {
               "image": "talis/app:worker-v1",
               "imagePullPolicy": "IfNotPresent",
+              "name": "app",
               "resources": Object {
                 "requests": Object {
                   "cpu": "100m",

--- a/test/background-worker/background-worker.test.ts
+++ b/test/background-worker/background-worker.test.ts
@@ -181,6 +181,57 @@ describe("BackgroundWorker", () => {
     });
   });
 
+  describe("Container name", () => {
+    test("Default container name", () => {
+      const results = synthBackgroundWorker();
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "app"
+      );
+    });
+
+    test("Container name from chart's app label", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        labels: {
+          app: "from-chart",
+        },
+      });
+      new BackgroundWorker(chart, "worker-test", requiredProps);
+      const results = Testing.synth(chart);
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-chart"
+      );
+    });
+
+    test("Container name from selector label", () => {
+      const results = synthBackgroundWorker({
+        ...requiredProps,
+        selectorLabels: { app: "from-selector" },
+      });
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-selector"
+      );
+    });
+
+    test("Container name set explicitly", () => {
+      const results = synthBackgroundWorker({
+        ...requiredProps,
+        containerName: "explicit-name",
+      });
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "explicit-name"
+      );
+    });
+  });
+
   describe("Custom stop signal", () => {
     test("Either stopSignal or lifecycle.preStop can be specified", () => {
       expect(() => {

--- a/test/web-service/__snapshots__/resque-web.test.ts.snap
+++ b/test/web-service/__snapshots__/resque-web.test.ts.snap
@@ -54,7 +54,7 @@ Array [
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/ssl-redirect": "443",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "instance=resque-web",
+        "alb.ingress.kubernetes.io/tags": "service=resque,instance=resque-web",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -133,6 +133,7 @@ Array [
             Object {
               "image": "talis/resque-web:stable",
               "imagePullPolicy": "IfNotPresent",
+              "name": "resque",
               "ports": Array [
                 Object {
                   "containerPort": 3000,
@@ -213,7 +214,7 @@ Array [
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/ssl-redirect": "443",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
-        "alb.ingress.kubernetes.io/tags": "instance=resque-web",
+        "alb.ingress.kubernetes.io/tags": "service=resque,instance=resque-web",
         "alb.ingress.kubernetes.io/target-type": "instance",
       },
       "labels": Object {
@@ -311,6 +312,7 @@ Array [
               ],
               "image": "talis/resque-web:latest",
               "imagePullPolicy": "IfNotPresent",
+              "name": "resque",
               "ports": Array [
                 Object {
                   "containerPort": 3000,

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -907,6 +907,7 @@ Array [
             Object {
               "image": "my-image",
               "imagePullPolicy": "IfNotPresent",
+              "name": "app",
               "ports": Array [
                 Object {
                   "containerPort": 3000,
@@ -1094,6 +1095,7 @@ Array [
             Object {
               "image": "my-image",
               "imagePullPolicy": "IfNotPresent",
+              "name": "app",
               "ports": Array [
                 Object {
                   "containerPort": 3000,

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -437,6 +437,50 @@ describe("WebService", () => {
     });
   });
 
+  describe("Container name", () => {
+    test("Default container name", () => {
+      const results = synthWebService();
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "app"
+      );
+    });
+
+    test("Container name from chart's app label", () => {
+      const results = synthWebService(defaultProps, { app: "from-chart" });
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-chart"
+      );
+    });
+
+    test("Container name from selector label", () => {
+      const results = synthWebService({
+        ...defaultProps,
+        selectorLabels: { app: "from-selector" },
+      });
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-selector"
+      );
+    });
+
+    test("Container name set explicitly", () => {
+      const results = synthWebService({
+        ...defaultProps,
+        containerName: "explicit-name",
+      });
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "explicit-name"
+      );
+    });
+  });
+
   describe("Labels and annotations", () => {
     test("Inherits labels from the chart", () => {
       const results = synthWebService(defaultProps, {


### PR DESCRIPTION
- Ensure container name is set even if `app` labels isn't
- Use custom selector `app` label in setting the container name
- Allow to explicitly set container name