### PR TITLE
fix: use deployment and region enums in helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 - `npm run lint` will check code quality and style guidelines (using ESlint and Prettier)
 - `npm run format` will format the code (using Prettier)
 - `npm run test` run tests
+- `npm run test -- --updateSnapshot` update the test snapshots

--- a/examples/simple-web-service/__snapshots__/main.test.ts.snap
+++ b/examples/simple-web-service/__snapshots__/main.test.ts.snap
@@ -48,7 +48,7 @@ Array [
       "annotations": Object {
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
-        "alb.ingress.kubernetes.io/load-balancer-name": "web",
+        "alb.ingress.kubernetes.io/load-balancer-name": "web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
         "alb.ingress.kubernetes.io/tags": "instance=web",

--- a/lib/common/name-util.ts
+++ b/lib/common/name-util.ts
@@ -1,3 +1,6 @@
+import { TalisShortRegion } from "../talis-chart/talis-region";
+import { TalisDeploymentEnvironment } from "../talis-chart/talis-deployment-environment";
+
 /**
  * Join an array of strings with a separator, omitting empty ones.
  */
@@ -8,16 +11,18 @@ export function joinNameParts(parts: (string | undefined)[]): string {
 /**
  * Abbreviate name of the environment.
  */
-function abbreviateEnvironment(environment: string): string {
+function abbreviateEnvironment(
+  environment: TalisDeploymentEnvironment
+): string {
   switch (environment) {
-    case "production":
+    case TalisDeploymentEnvironment.PRODUCTION:
       return "prod";
 
-    case "ondemand":
+    case TalisDeploymentEnvironment.ONDEMAND:
       // Omit, because namespace should include watermark.
       return "";
 
-    case "development":
+    case TalisDeploymentEnvironment.DEVELOPMENT:
       // We want it to be the same as or longer than "production".
       // Also it's the same length (7) as "staging".
       return "develop";
@@ -30,9 +35,9 @@ function abbreviateEnvironment(environment: string): string {
 /**
  * Abbreviate name of the region.
  */
-function abbreviateRegion(region: string): string {
+function abbreviateRegion(region: TalisShortRegion): string {
   switch (region) {
-    case "local":
+    case TalisShortRegion.LOCAL:
       // Omit
       return "";
 
@@ -49,14 +54,16 @@ export function makeLoadBalancerName(
   instanceLabels: {
     instance?: string;
     canary?: string;
-    environment?: string;
-    region?: string;
+    environment?: TalisDeploymentEnvironment;
+    region?: TalisShortRegion;
   }
 ): string {
   const { instance, canary, environment, region } = instanceLabels;
   const canarySuffix = canary && canary === "true" ? "c" : undefined;
-  const envShort = abbreviateEnvironment(environment ?? "");
-  const regShort = abbreviateRegion(region ?? "");
+  const envShort = abbreviateEnvironment(
+    environment ?? TalisDeploymentEnvironment.DEVELOPMENT
+  );
+  const regShort = abbreviateRegion(region ?? TalisShortRegion.LOCAL);
 
   return joinNameParts([namespace, instance, canarySuffix, envShort, regShort]);
 }

--- a/lib/web-service/annotation-util.ts
+++ b/lib/web-service/annotation-util.ts
@@ -1,21 +1,23 @@
+import { TalisShortRegion } from "../talis-chart/talis-region";
+import { TalisDeploymentEnvironment } from "../talis-chart/talis-deployment-environment";
+
 function resolveEnvironmentRegionUrlPart(
-  environment: string,
-  region: string
+  environment: TalisDeploymentEnvironment,
+  region: TalisShortRegion
 ): string {
-  switch (`${environment}-${region}`) {
-    case "production-ca":
+  if (environment === TalisDeploymentEnvironment.PRODUCTION) {
+    if (region === TalisShortRegion.CANADA) {
       return ".ca";
-    case "production-eu":
-      return "-eu";
-    default:
-      return "-staging-eu";
+    }
+    return "-eu";
   }
+  return "-staging-eu";
 }
 
 function getServiceUrl(
   service: string,
-  environment: string,
-  region: string
+  environment: TalisDeploymentEnvironment,
+  region: TalisShortRegion
 ): string {
   const envRegionPart = resolveEnvironmentRegionUrlPart(environment, region);
   return `https://${service}-eks${envRegionPart}.talisaspire.com`;
@@ -25,8 +27,8 @@ function getServiceUrl(
  * Returns the URL for the Kubernetes Dashboard for the given namespace.
  */
 export function getEksDashboardUrl(
-  environment: string,
-  region: string,
+  environment: TalisDeploymentEnvironment,
+  region: TalisShortRegion,
   namespace: string
 ): string {
   const dashboardUrl = getServiceUrl("dashboard", environment, region);
@@ -37,8 +39,8 @@ export function getEksDashboardUrl(
  * Returns the URL for the Grafana workloads dashboard for the given namespace.
  */
 export function getGraphsUrl(
-  environment: string,
-  region: string,
+  environment: TalisDeploymentEnvironment,
+  region: TalisShortRegion,
   namespace: string
 ): string {
   const grafanaUrl = getServiceUrl("grafana", environment, region);
@@ -50,8 +52,8 @@ export function getGraphsUrl(
  * Returns the URL for the Loki logs dashboard for the given app.
  */
 export function getLogsUrl(
-  environment: string,
-  region: string,
+  environment: TalisDeploymentEnvironment,
+  region: TalisShortRegion,
   app: string
 ): string {
   const grafanaUrl = getServiceUrl("grafana", environment, region);

--- a/lib/web-service/env-util.ts
+++ b/lib/web-service/env-util.ts
@@ -1,8 +1,9 @@
 import { CanaryStage, canaryStages } from ".";
+import { TalisDeploymentEnvironment } from "../talis-chart/talis-deployment-environment";
 
 export function getDockerTag(
   envVarName: string,
-  environment: string,
+  environment: TalisDeploymentEnvironment,
   defaultTag = "latest"
 ): string {
   const tag = process.env[envVarName] ?? defaultTag;
@@ -12,7 +13,10 @@ export function getDockerTag(
   }
 
   if (
-    ["production", "staging"].includes(environment) &&
+    [
+      TalisDeploymentEnvironment.PRODUCTION,
+      TalisDeploymentEnvironment.STAGING,
+    ].includes(environment) &&
     ["latest", "stable", "release"].includes(tag)
   ) {
     throw new Error(

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lint": "npm run lint:prettier && npm run lint:eslint && npm run lint:ts",
     "prepare": "husky install",
     "release": "npm run build && semantic-release",
-    "test": "jest",
-    "test:update": "jest --updateSnapshot"
+    "test": "jest"
   },
   "peerDependencies": {
     "cdk8s": "^2.2.18",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint": "npm run lint:prettier && npm run lint:eslint && npm run lint:ts",
     "prepare": "husky install",
     "release": "npm run build && semantic-release",
-    "test": "jest"
+    "test": "jest",
+    "test:update": "jest --updateSnapshot"
   },
   "peerDependencies": {
     "cdk8s": "^2.2.18",

--- a/test/common/name-util.test.ts
+++ b/test/common/name-util.test.ts
@@ -24,7 +24,7 @@ describe("name-util", () => {
         // empty
         namespace: "",
         labels: {},
-        expected: "",
+        expected: "develop",
       },
       {
         // local development
@@ -32,7 +32,7 @@ describe("name-util", () => {
         labels: {
           instance: "api",
           environment: TalisDeploymentEnvironment.DEVELOPMENT,
-          region: TalisShortRegion.EU,
+          region: TalisShortRegion.LOCAL,
         },
         expected: "my-app-api-develop",
       },

--- a/test/common/name-util.test.ts
+++ b/test/common/name-util.test.ts
@@ -1,4 +1,6 @@
+import { TalisShortRegion } from "../../lib";
 import { joinNameParts, makeLoadBalancerName } from "../../lib/common";
+import { TalisDeploymentEnvironment } from "../../lib/talis-chart/talis-deployment-environment";
 
 describe("name-util", () => {
   describe("joinNameParts", () => {
@@ -29,8 +31,8 @@ describe("name-util", () => {
         namespace: "my-app",
         labels: {
           instance: "api",
-          environment: "development",
-          region: "local",
+          environment: TalisDeploymentEnvironment.DEVELOPMENT,
+          region: TalisShortRegion.EU,
         },
         expected: "my-app-api-develop",
       },
@@ -39,8 +41,8 @@ describe("name-util", () => {
         namespace: "my-app",
         labels: {
           instance: "api",
-          environment: "staging",
-          region: "eu",
+          environment: TalisDeploymentEnvironment.STAGING,
+          region: TalisShortRegion.EU,
         },
         expected: "my-app-api-staging-eu",
       },
@@ -49,8 +51,8 @@ describe("name-util", () => {
         namespace: "my-app",
         labels: {
           instance: "api",
-          environment: "production",
-          region: "ca",
+          environment: TalisDeploymentEnvironment.PRODUCTION,
+          region: TalisShortRegion.CANADA,
         },
         expected: "my-app-api-prod-ca",
       },
@@ -60,8 +62,8 @@ describe("name-util", () => {
         labels: {
           instance: "api",
           canary: "false",
-          environment: "production",
-          region: "eu",
+          environment: TalisDeploymentEnvironment.PRODUCTION,
+          region: TalisShortRegion.EU,
         },
         expected: "my-app-api-prod-eu",
       },
@@ -71,8 +73,8 @@ describe("name-util", () => {
         labels: {
           instance: "api",
           canary: "true",
-          environment: "production",
-          region: "eu",
+          environment: TalisDeploymentEnvironment.PRODUCTION,
+          region: TalisShortRegion.EU,
         },
         expected: "my-app-api-c-prod-eu",
       },
@@ -82,8 +84,8 @@ describe("name-util", () => {
         labels: {
           instance: "api",
           canary: "true",
-          environment: "ondemand",
-          region: "eu",
+          environment: TalisDeploymentEnvironment.ONDEMAND,
+          region: TalisShortRegion.EU,
         },
         expected: "my-app-repo-1234-api-c-eu",
       },

--- a/test/web-service/__snapshots__/resque-web.test.ts.snap
+++ b/test/web-service/__snapshots__/resque-web.test.ts.snap
@@ -50,7 +50,7 @@ Array [
       "annotations": Object {
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
-        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web",
+        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
         "alb.ingress.kubernetes.io/tags": "service=resque,instance=resque-web",
         "alb.ingress.kubernetes.io/target-type": "instance",
@@ -208,7 +208,7 @@ Array [
       "annotations": Object {
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
-        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web",
+        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
         "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
         "alb.ingress.kubernetes.io/ssl-redirect": "443",
         "alb.ingress.kubernetes.io/success-codes": "200,303",

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -829,7 +829,7 @@ Array [
       "annotations": Object {
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
-        "alb.ingress.kubernetes.io/load-balancer-name": "test-web",
+        "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
         "alb.ingress.kubernetes.io/tags": "instance=web",
         "alb.ingress.kubernetes.io/target-type": "instance",
@@ -1015,7 +1015,7 @@ Array [
       "annotations": Object {
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
-        "alb.ingress.kubernetes.io/load-balancer-name": "test-web",
+        "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
         "alb.ingress.kubernetes.io/success-codes": "200,303",
         "alb.ingress.kubernetes.io/tags": "instance=web",
         "alb.ingress.kubernetes.io/target-type": "instance",

--- a/test/web-service/annotation-util.test.ts
+++ b/test/web-service/annotation-util.test.ts
@@ -5,14 +5,16 @@ import {
   convertToStringList,
   convertToStringMap,
   convertToJsonContent,
+  TalisDeploymentEnvironment,
+  TalisShortRegion,
 } from "../../lib";
 
 describe("annotation-util", () => {
   describe("eksDashboardUrl, graphsUrl, logsUrl", () => {
     [
       {
-        environment: "staging",
-        region: "eu",
+        environment: TalisDeploymentEnvironment.STAGING,
+        region: TalisShortRegion.EU,
         app: "test1",
         expected: {
           eksDashboardUrl:
@@ -24,8 +26,8 @@ describe("annotation-util", () => {
         },
       },
       {
-        environment: "production",
-        region: "eu",
+        environment: TalisDeploymentEnvironment.PRODUCTION,
+        region: TalisShortRegion.EU,
         app: "test2",
         expected: {
           eksDashboardUrl:
@@ -37,8 +39,8 @@ describe("annotation-util", () => {
         },
       },
       {
-        environment: "production",
-        region: "ca",
+        environment: TalisDeploymentEnvironment.PRODUCTION,
+        region: TalisShortRegion.CANADA,
         app: "test3",
         expected: {
           eksDashboardUrl:
@@ -50,8 +52,8 @@ describe("annotation-util", () => {
         },
       },
       {
-        environment: "ondemand",
-        region: "eu",
+        environment: TalisDeploymentEnvironment.ONDEMAND,
+        region: TalisShortRegion.EU,
         app: "test4",
         expected: {
           eksDashboardUrl:

--- a/test/web-service/env-util.test.ts
+++ b/test/web-service/env-util.test.ts
@@ -1,4 +1,8 @@
-import { getCanaryStage, getDockerTag } from "../../lib";
+import {
+  getCanaryStage,
+  getDockerTag,
+  TalisDeploymentEnvironment,
+} from "../../lib";
 
 describe("env-util", () => {
   const PROCESS_ENV = process.env;
@@ -15,30 +19,38 @@ describe("env-util", () => {
   describe("getDockerTag", () => {
     test("Gets a Docker tag from named env var", () => {
       process.env.APP_DOCKER_TAG = "v1";
-      expect(getDockerTag("APP_DOCKER_TAG", "development")).toBe("v1");
+      expect(
+        getDockerTag("APP_DOCKER_TAG", TalisDeploymentEnvironment.DEVELOPMENT)
+      ).toBe("v1");
     });
 
     test("Gets the default Docker tag if env var is not set", () => {
-      expect(getDockerTag("APP_DOCKER_TAG", "development")).toBe("latest");
+      expect(
+        getDockerTag("APP_DOCKER_TAG", TalisDeploymentEnvironment.DEVELOPMENT)
+      ).toBe("latest");
     });
 
     test("Gets the custom default Docker tag if env var is not set", () => {
-      expect(getDockerTag("APP_DOCKER_TAG", "development", "release")).toBe(
-        "release"
-      );
+      expect(
+        getDockerTag(
+          "APP_DOCKER_TAG",
+          TalisDeploymentEnvironment.DEVELOPMENT,
+          "release"
+        )
+      ).toBe("release");
     });
 
     test("Throws if env var is empty", () => {
       process.env.APP_DOCKER_TAG = "";
       expect(() =>
-        getDockerTag("APP_DOCKER_TAG", "development")
+        getDockerTag("APP_DOCKER_TAG", TalisDeploymentEnvironment.DEVELOPMENT)
       ).toThrowErrorMatchingSnapshot();
     });
 
     test("Throws if tag is not valid for the environment", () => {
       process.env.APP_DOCKER_TAG = "stable";
       expect(() =>
-        getDockerTag("APP_DOCKER_TAG", "production")
+        getDockerTag("APP_DOCKER_TAG", TalisDeploymentEnvironment.PRODUCTION)
       ).toThrowErrorMatchingSnapshot();
     });
   });


### PR DESCRIPTION
Use the recently created enums in the helper functions.