### PR TITLE
feat: add cron-job construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
   - Supports setting binary data.
   - Example use can be found in [WebService advanced example](./examples/advanced-web-service/README.md).
 
+- `CronJob`
+
+  - Represents a Cron Job that is run based on a schedule.
+  - Supports setting the Schedule.
+  - The command to run is defined as part of the container spec.
+  - Details in an [example](./examples/cron-job/README.md).
+
 - `Secret`
 
   - Represents a Kubernetes Secret.

--- a/examples/cron-job/README.md
+++ b/examples/cron-job/README.md
@@ -1,0 +1,25 @@
+# Cron-Job construct example
+
+Demonstrates a Cron-Job.
+
+## Usage
+
+In order to synthesize the example to Kubernetes YAML, you need to run the following command:
+
+```sh
+npx cdk8s synth
+```
+
+This will produce `dist/app.k8s.yaml` file which you can then apply to your cluster:
+
+```sh
+kubectl apply -f dist/app.k8s.yaml
+```
+
+## Testing
+
+You can run the tests with the following command:
+
+```sh
+npm test -- examples/cron-job
+```

--- a/examples/cron-job/__snapshots__/chart.test.ts.snap
+++ b/examples/cron-job/__snapshots__/chart.test.ts.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CronJob example Change release version 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "example-cron-app-test",
+      "namespace": "example-cron-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      ".dockerconfigjson": "eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImMyOXRaWFZ6WlhJNmMyVmpjbVYwTVRJeiJ9fX0=",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "docker-hub-cred",
+      "namespace": "example-cron-app-test",
+    },
+    "type": "kubernetes.io/dockerconfigjson",
+  },
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "instance": "cron-job-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v2.2",
+        "role": "cronjob",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "cron-job-example",
+      "namespace": "example-cron-app-test",
+    },
+    "spec": Object {
+      "jobTemplate": Object {
+        "spec": Object {
+          "template": Object {
+            "spec": Object {
+              "containers": Array [
+                Object {
+                  "command": Array [
+                    "/bin/sh",
+                    "-c",
+                    "echo hello",
+                  ],
+                  "image": "docker.io/organization/my-app:cron-v2.2",
+                  "imagePullPolicy": "IfNotPresent",
+                  "name": "example-cron-app",
+                  "resources": Object {
+                    "requests": Object {
+                      "cpu": "100m",
+                      "memory": "100Mi",
+                    },
+                  },
+                  "workingDir": "/some/path",
+                },
+              ],
+            },
+          },
+        },
+      },
+      "schedule": "0 0 13 * 5",
+    },
+  },
+]
+`;
+
+exports[`CronJob example Snapshot 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "example-cron-app-test",
+      "namespace": "example-cron-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      ".dockerconfigjson": "eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImMyOXRaWFZ6WlhJNmMyVmpjbVYwTVRJeiJ9fX0=",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "docker-hub-cred",
+      "namespace": "example-cron-app-test",
+    },
+    "type": "kubernetes.io/dockerconfigjson",
+  },
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-cron-app",
+        "environment": "development",
+        "instance": "cron-job-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "cronjob",
+        "service": "example-cron-app-development-local",
+      },
+      "name": "cron-job-example",
+      "namespace": "example-cron-app-test",
+    },
+    "spec": Object {
+      "jobTemplate": Object {
+        "spec": Object {
+          "template": Object {
+            "spec": Object {
+              "containers": Array [
+                Object {
+                  "command": Array [
+                    "/bin/sh",
+                    "-c",
+                    "echo hello",
+                  ],
+                  "image": "docker.io/organization/my-app:cron-v1.0",
+                  "imagePullPolicy": "IfNotPresent",
+                  "name": "example-cron-app",
+                  "resources": Object {
+                    "requests": Object {
+                      "cpu": "100m",
+                      "memory": "100Mi",
+                    },
+                  },
+                  "workingDir": "/some/path",
+                },
+              ],
+            },
+          },
+        },
+      },
+      "schedule": "0 0 13 * 5",
+    },
+  },
+]
+`;

--- a/examples/cron-job/cdk8s.yaml
+++ b/examples/cron-job/cdk8s.yaml
@@ -1,0 +1,2 @@
+language: typescript
+app: ts-node main.ts

--- a/examples/cron-job/chart.test.ts
+++ b/examples/cron-job/chart.test.ts
@@ -1,0 +1,41 @@
+import { CronJobChart } from "./chart";
+import { Testing } from "cdk8s";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+describe("CronJob example", () => {
+  const PROCESS_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...PROCESS_ENV };
+    process.env.DOCKER_USERNAME = "someuser";
+    process.env.DOCKER_PASSWORD = "secret123";
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV;
+  });
+
+  test("Snapshot", () => {
+    const app = Testing.app();
+    const chart = new CronJobChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("Change release version", () => {
+    process.env.RELEASE = "v2.2";
+    const app = Testing.app();
+    const chart = new CronJobChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/examples/cron-job/chart.ts
+++ b/examples/cron-job/chart.ts
@@ -1,0 +1,33 @@
+import { Construct } from "constructs";
+import {
+  createDockerHubSecretFromEnv,
+  CronJob,
+  getDockerTag,
+  TalisChart,
+  TalisChartProps,
+} from "../../lib";
+import { Quantity } from "../../imports/k8s";
+
+export class CronJobChart extends TalisChart {
+  constructor(scope: Construct, props: TalisChartProps) {
+    super(scope, { app: "example-cron-app", ...props });
+
+    const release = getDockerTag("RELEASE", props.environment, "v1.0");
+    const dockerHubSecret = createDockerHubSecretFromEnv(this);
+
+    new CronJob(this, "cron-job-example", {
+      schedule: "0 0 13 * 5",
+      image: `docker.io/organization/my-app:cron-${release}`,
+      imagePullSecrets: [{ name: dockerHubSecret.name }],
+      release,
+      workingDir: "/some/path",
+      command: ["/bin/sh", "-c", "echo hello"],
+      resources: {
+        requests: {
+          cpu: Quantity.fromString("100m"),
+          memory: Quantity.fromString("100Mi"),
+        },
+      },
+    });
+  }
+}

--- a/examples/cron-job/main.ts
+++ b/examples/cron-job/main.ts
@@ -1,0 +1,11 @@
+import { App } from "cdk8s";
+import { CronJobChart } from "./chart";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+const app = new App();
+new CronJobChart(app, {
+  environment: TalisDeploymentEnvironment.DEVELOPMENT,
+  region: TalisShortRegion.LOCAL,
+  watermark: "example",
+});
+app.synth();

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -1,0 +1,25 @@
+import { ContainerProps } from "../common";
+import { LocalObjectReference, Volume } from "../../imports/k8s";
+
+export interface CronJobProps
+  extends Omit<ContainerProps, "readinessProbe" | "livenessProbe"> {
+  /** The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron */
+  readonly schedule: string;
+
+  /**
+   * Custom selector labels, they will be merged with the default app, role, and instance.
+   * They will be applied to the workload, the pod and the service.
+   * @default { app: "<app label from chart>", role: "worker", instance: "<construct id>" }
+   */
+  readonly selectorLabels?: { [key: string]: string };
+
+  /**
+   * A list of references to secrets in the same namespace to use for pulling any of the images.
+   */
+  readonly imagePullSecrets?: LocalObjectReference[];
+
+  /**
+   * list of volumes that can be mounted by containers belonging to the pod.
+   */
+  readonly volumes?: Volume[];
+}

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -9,7 +9,7 @@ export interface CronJobProps
   /**
    * Custom selector labels, they will be merged with the default app, role, and instance.
    * They will be applied to the workload, the pod and the service.
-   * @default { app: "<app label from chart>", role: "worker", instance: "<construct id>" }
+   * @default { app: "<app label from chart>", role: "cronjob", instance: "<construct id>" }
    */
   readonly selectorLabels?: { [key: string]: string };
 

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -32,6 +32,7 @@ export class CronJob extends Construct {
           spec: {
             template: {
               spec: {
+                volumes: props.volumes,
                 containers: [
                   {
                     name: props.containerName ?? app ?? "app",

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -1,0 +1,63 @@
+import { Chart } from "cdk8s";
+import { Construct } from "constructs";
+import { KubeCronJob } from "../../imports/k8s";
+import { CronJobProps } from "./cron-job-props";
+
+export class CronJob extends Construct {
+  constructor(scope: Construct, id: string, props: CronJobProps) {
+    super(scope, id);
+    this.validateProps(props);
+
+    const chart = Chart.of(this);
+    const app = chart.labels.app ?? props.selectorLabels?.app;
+    const labels = {
+      ...chart.labels,
+      release: props.release,
+    };
+
+    const selectorLabels: { [key: string]: string } = {
+      app: app,
+      role: "cronjob",
+      instance: id,
+      ...props.selectorLabels,
+    };
+
+    new KubeCronJob(this, id, {
+      metadata: {
+        labels: { ...labels, ...selectorLabels },
+      },
+      spec: {
+        schedule: props.schedule,
+        jobTemplate: {
+          spec: {
+            template: {
+              spec: {
+                containers: [
+                  {
+                    name: props.containerName ?? app ?? "app",
+                    image: props.image,
+                    imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+                    workingDir: props.workingDir,
+                    command: props.command,
+                    args: props.args,
+                    resources: props.resources,
+                    securityContext: props.securityContext,
+                    env: props.env,
+                    envFrom: props.envFrom,
+                    volumeMounts: props.volumeMounts,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  validateProps(props: CronJobProps): void {
+    if (!props.schedule) {
+      throw new Error("Schedule must be specified");
+    }
+  }
+}

--- a/lib/cron-job/index.ts
+++ b/lib/cron-job/index.ts
@@ -1,0 +1,2 @@
+export * from "./cron-job-props";
+export * from "./cron-job";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
+export * from "./cron-job";
 export * from "./background-worker";
 export * from "./data";
 export * from "./talis-chart";

--- a/test/cron-job/__snapshots__/cron-job.test.ts.snap
+++ b/test/cron-job/__snapshots__/cron-job.test.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CronJob Props All the props 1`] = `
+Array [
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "cronjob",
+      },
+      "name": "test-cron-job-test-c88f7970",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "jobTemplate": Object {
+        "spec": Object {
+          "template": Object {
+            "spec": Object {
+              "containers": Array [
+                Object {
+                  "args": Array [
+                    "--foo",
+                    "bar",
+                  ],
+                  "command": Array [
+                    "/bin/sh",
+                    "-c",
+                    "echo hello",
+                  ],
+                  "env": Array [
+                    Object {
+                      "name": "FOO",
+                      "value": "bar",
+                    },
+                  ],
+                  "envFrom": Array [
+                    Object {
+                      "configMapRef": Object {
+                        "name": "foo-config",
+                      },
+                    },
+                  ],
+                  "image": "talis/app:worker-v1",
+                  "imagePullPolicy": "Always",
+                  "name": "my-app",
+                  "resources": Object {
+                    "limits": Object {
+                      "cpu": 1,
+                      "memory": "1Gi",
+                    },
+                    "requests": Object {
+                      "cpu": 0.1,
+                      "memory": "100Mi",
+                    },
+                  },
+                  "securityContext": Object {
+                    "runAsGroup": 1000,
+                    "runAsNonRoot": true,
+                    "runAsUser": 1000,
+                  },
+                  "workingDir": "/some/path",
+                },
+              ],
+            },
+          },
+        },
+      },
+      "schedule": "0 0 13 * 5",
+    },
+  },
+]
+`;
+
+exports[`CronJob Props Minimal required props 1`] = `
+Array [
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "cron-job-test",
+        "release": "v1",
+        "role": "cronjob",
+      },
+      "name": "test-cron-job-test-c88f7970",
+    },
+    "spec": Object {
+      "jobTemplate": Object {
+        "spec": Object {
+          "template": Object {
+            "spec": Object {
+              "containers": Array [
+                Object {
+                  "image": "talis/app:worker-v1",
+                  "imagePullPolicy": "IfNotPresent",
+                  "name": "app",
+                  "resources": Object {
+                    "requests": Object {
+                      "cpu": "100m",
+                      "memory": "100Mi",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      "schedule": "0 0 13 * 5",
+    },
+  },
+]
+`;

--- a/test/cron-job/cron-job.test.ts
+++ b/test/cron-job/cron-job.test.ts
@@ -1,0 +1,140 @@
+import { Chart, Testing } from "cdk8s";
+import { Quantity } from "../../imports/k8s";
+import { CronJob, CronJobProps } from "../../lib";
+
+const requiredProps = {
+  schedule: "0 0 13 * 5",
+  image: "talis/app:worker-v1",
+  release: "v1",
+  resources: {
+    requests: {
+      cpu: Quantity.fromString("100m"),
+      memory: Quantity.fromString("100Mi"),
+    },
+  },
+};
+
+function synthCronJob(props: CronJobProps = requiredProps) {
+  const chart = Testing.chart();
+  new CronJob(chart, "cron-job-test", props);
+  const results = Testing.synth(chart);
+  return results;
+}
+
+describe("CronJob", () => {
+  describe("Props", () => {
+    test("Minimal required props", () => {
+      const chart = Testing.chart();
+      new CronJob(chart, "cron-job-test", requiredProps);
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("All the props", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        namespace: "test",
+        labels: {
+          app: "my-app",
+          environment: "test",
+          region: "local",
+        },
+      });
+      const selectorLabels = {
+        app: "my-app",
+        role: "cronjob",
+        instance: "test",
+      };
+      new CronJob(chart, "cron-job-test", {
+        ...requiredProps,
+        selectorLabels,
+        workingDir: "/some/path",
+        command: ["/bin/sh", "-c", "echo hello"],
+        args: ["--foo", "bar"],
+        env: [{ name: "FOO", value: "bar" }],
+        envFrom: [{ configMapRef: { name: "foo-config" } }],
+        imagePullPolicy: "Always",
+        resources: {
+          requests: {
+            cpu: Quantity.fromNumber(0.1),
+            memory: Quantity.fromString("100Mi"),
+          },
+          limits: {
+            cpu: Quantity.fromNumber(1),
+            memory: Quantity.fromString("1Gi"),
+          },
+        },
+        securityContext: {
+          runAsUser: 1000,
+          runAsGroup: 1000,
+          runAsNonRoot: true,
+        },
+        lifecycle: {
+          postStart: {
+            exec: {
+              command: ["/bin/sh", "-c", "echo hello"],
+            },
+          },
+          preStop: {
+            exec: {
+              command: ["/bin/sh", "-c", "echo goodbye"],
+            },
+          },
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Container name", () => {
+    test("Default container name", () => {
+      const results = synthCronJob();
+      const cron = results.find((obj) => obj.kind === "CronJob");
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.spec.containers[0].name",
+        "app"
+      );
+    });
+
+    test("Container name from chart's app label", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        labels: {
+          app: "from-chart",
+        },
+      });
+      new CronJob(chart, "worker-test", requiredProps);
+      const results = Testing.synth(chart);
+      const cron = results.find((obj) => obj.kind === "CronJob");
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.spec.containers[0].name",
+        "from-chart"
+      );
+    });
+
+    test("Container name from selector label", () => {
+      const results = synthCronJob({
+        ...requiredProps,
+        selectorLabels: { app: "from-selector" },
+      });
+      const cron = results.find((obj) => obj.kind === "CronJob");
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.spec.containers[0].name",
+        "from-selector"
+      );
+    });
+
+    test("Container name set explicitly", () => {
+      const results = synthCronJob({
+        ...requiredProps,
+        containerName: "explicit-name",
+      });
+      const cron = results.find((obj) => obj.kind === "CronJob");
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.spec.containers[0].name",
+        "explicit-name"
+      );
+    });
+  });
+});


### PR DESCRIPTION
- this relates to talis/platform#5428

This P/R adds a new cdk8s construct that represents a Cron-Job which can be executed based on a defined schedule.

- [x] adds a new `CronJob` construct.
- [x] adds examples and docs