### PR TITLE
feat: adds a Job construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
   - The command to run is defined as part of the container spec.
   - Details in an [example](./examples/cron-job/README.md).
 
+- `Job`
+
+  - Represents a single run Job.
+  - The command to run is defined as part of the container spec.
+  - Details in an [example](./examples/job/README.md).
+
 - `Secret`
 
   - Represents a Kubernetes Secret.

--- a/examples/job/README.md
+++ b/examples/job/README.md
@@ -1,0 +1,25 @@
+# Job construct example
+
+Demonstrates a Job.
+
+## Usage
+
+In order to synthesize the example to Kubernetes YAML, you need to run the following command:
+
+```sh
+npx cdk8s synth
+```
+
+This will produce `dist/app.k8s.yaml` file which you can then apply to your cluster:
+
+```sh
+kubectl apply -f dist/app.k8s.yaml
+```
+
+## Testing
+
+You can run the tests with the following command:
+
+```sh
+npm test -- examples/job
+```

--- a/examples/job/__snapshots__/chart.test.ts.snap
+++ b/examples/job/__snapshots__/chart.test.ts.snap
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Job example Change release version 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-job-app-development-local",
+      },
+      "name": "example-job-app-test",
+      "namespace": "example-job-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      ".dockerconfigjson": "eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImMyOXRaWFZ6WlhJNmMyVmpjbVYwTVRJeiJ9fX0=",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-job-app-development-local",
+      },
+      "name": "docker-hub-cred",
+      "namespace": "example-job-app-test",
+    },
+    "type": "kubernetes.io/dockerconfigjson",
+  },
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "instance": "job-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v2.2",
+        "role": "job",
+        "service": "example-job-app-development-local",
+      },
+      "name": "job-example",
+      "namespace": "example-job-app-test",
+    },
+    "spec": Object {
+      "template": Object {
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "/bin/sh",
+                "-c",
+                "echo hello",
+              ],
+              "image": "docker.io/organization/my-app:job-v2.2",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "example-job-app",
+              "resources": Object {
+                "requests": Object {
+                  "cpu": "100m",
+                  "memory": "100Mi",
+                },
+              },
+              "workingDir": "/some/path",
+            },
+          ],
+        },
+      },
+      "ttlSecondsAfterFinished": 100,
+    },
+  },
+]
+`;
+
+exports[`Job example Snapshot 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-job-app-development-local",
+      },
+      "name": "example-job-app-test",
+      "namespace": "example-job-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "data": Object {
+      ".dockerconfigjson": "eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImMyOXRaWFZ6WlhJNmMyVmpjbVYwTVRJeiJ9fX0=",
+    },
+    "kind": "Secret",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-job-app-development-local",
+      },
+      "name": "docker-hub-cred",
+      "namespace": "example-job-app-test",
+    },
+    "type": "kubernetes.io/dockerconfigjson",
+  },
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-job-app",
+        "environment": "development",
+        "instance": "job-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "job",
+        "service": "example-job-app-development-local",
+      },
+      "name": "job-example",
+      "namespace": "example-job-app-test",
+    },
+    "spec": Object {
+      "template": Object {
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "/bin/sh",
+                "-c",
+                "echo hello",
+              ],
+              "image": "docker.io/organization/my-app:job-v1.0",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "example-job-app",
+              "resources": Object {
+                "requests": Object {
+                  "cpu": "100m",
+                  "memory": "100Mi",
+                },
+              },
+              "workingDir": "/some/path",
+            },
+          ],
+        },
+      },
+      "ttlSecondsAfterFinished": 100,
+    },
+  },
+]
+`;

--- a/examples/job/cdk8s.yaml
+++ b/examples/job/cdk8s.yaml
@@ -1,0 +1,2 @@
+language: typescript
+app: ts-node main.ts

--- a/examples/job/chart.test.ts
+++ b/examples/job/chart.test.ts
@@ -1,0 +1,41 @@
+import { JobChart } from "./chart";
+import { Testing } from "cdk8s";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+describe("Job example", () => {
+  const PROCESS_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...PROCESS_ENV };
+    process.env.DOCKER_USERNAME = "someuser";
+    process.env.DOCKER_PASSWORD = "secret123";
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV;
+  });
+
+  test("Snapshot", () => {
+    const app = Testing.app();
+    const chart = new JobChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("Change release version", () => {
+    process.env.RELEASE = "v2.2";
+    const app = Testing.app();
+    const chart = new JobChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/examples/job/chart.ts
+++ b/examples/job/chart.ts
@@ -1,0 +1,33 @@
+import { Construct } from "constructs";
+import {
+  createDockerHubSecretFromEnv,
+  Job,
+  getDockerTag,
+  TalisChart,
+  TalisChartProps,
+} from "../../lib";
+import { Quantity } from "../../imports/k8s";
+
+export class JobChart extends TalisChart {
+  constructor(scope: Construct, props: TalisChartProps) {
+    super(scope, { app: "example-job-app", ...props });
+
+    const release = getDockerTag("RELEASE", props.environment, "v1.0");
+    const dockerHubSecret = createDockerHubSecretFromEnv(this);
+
+    new Job(this, "job-example", {
+      ttlSecondsAfterFinished: 100,
+      image: `docker.io/organization/my-app:job-${release}`,
+      imagePullSecrets: [{ name: dockerHubSecret.name }],
+      release,
+      workingDir: "/some/path",
+      command: ["/bin/sh", "-c", "echo hello"],
+      resources: {
+        requests: {
+          cpu: Quantity.fromString("100m"),
+          memory: Quantity.fromString("100Mi"),
+        },
+      },
+    });
+  }
+}

--- a/examples/job/main.ts
+++ b/examples/job/main.ts
@@ -1,0 +1,11 @@
+import { App } from "cdk8s";
+import { JobChart } from "./chart";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+const app = new App();
+new JobChart(app, {
+  environment: TalisDeploymentEnvironment.DEVELOPMENT,
+  region: TalisShortRegion.LOCAL,
+  watermark: "example",
+});
+app.synth();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./cron-job";
 export * from "./background-worker";
 export * from "./data";
+export * from "./job";
 export * from "./talis-chart";
 export * from "./web-service";

--- a/lib/job/index.ts
+++ b/lib/job/index.ts
@@ -1,0 +1,2 @@
+export * from "./job-props";
+export * from "./job";

--- a/lib/job/job-props.ts
+++ b/lib/job/job-props.ts
@@ -1,0 +1,32 @@
+import { ContainerProps } from "../common";
+import { LocalObjectReference, Volume } from "../../imports/k8s";
+
+export interface JobProps
+  extends Omit<ContainerProps, "readinessProbe" | "livenessProbe"> {
+  /**
+   * Custom selector labels, they will be merged with the default app, role, and instance.
+   * They will be applied to the workload, the pod and the service.
+   * @default { app: "<app label from chart>", role: "cronjob", instance: "<construct id>" }
+   */
+  readonly selectorLabels?: { [key: string]: string };
+
+  /**
+   * A list of references to secrets in the same namespace to use for pulling any of the images.
+   */
+  readonly imagePullSecrets?: LocalObjectReference[];
+
+  /**
+   * list of volumes that can be mounted by containers belonging to the pod.
+   */
+  readonly volumes?: Volume[];
+
+  /**
+   * ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete
+   * or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible
+   * to be automatically deleted. When the Job is being deleted, its lifecycle guarantees
+   * (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted.
+   * If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
+   * This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
+   */
+  readonly ttlSecondsAfterFinished?: number;
+}

--- a/lib/job/job.ts
+++ b/lib/job/job.ts
@@ -1,0 +1,53 @@
+import { Chart } from "cdk8s";
+import { Construct } from "constructs";
+import { KubeJob } from "../../imports/k8s";
+import { JobProps } from "./job-props";
+
+export class Job extends Construct {
+  constructor(scope: Construct, id: string, props: JobProps) {
+    super(scope, id);
+
+    const chart = Chart.of(this);
+    const app = chart.labels.app ?? props.selectorLabels?.app;
+    const labels = {
+      ...chart.labels,
+      release: props.release,
+    };
+
+    const selectorLabels: { [key: string]: string } = {
+      app: app,
+      role: "job",
+      instance: id,
+      ...props.selectorLabels,
+    };
+
+    new KubeJob(this, id, {
+      metadata: {
+        labels: { ...labels, ...selectorLabels },
+      },
+      spec: {
+        ttlSecondsAfterFinished: props.ttlSecondsAfterFinished,
+        template: {
+          spec: {
+            volumes: props.volumes,
+            containers: [
+              {
+                name: props.containerName ?? app ?? "app",
+                image: props.image,
+                imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+                workingDir: props.workingDir,
+                command: props.command,
+                args: props.args,
+                resources: props.resources,
+                securityContext: props.securityContext,
+                env: props.env,
+                envFrom: props.envFrom,
+                volumeMounts: props.volumeMounts,
+              },
+            ],
+          },
+        },
+      },
+    });
+  }
+}

--- a/test/job/__snapshots__/job.test.ts.snap
+++ b/test/job/__snapshots__/job.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Job Props All the props 1`] = `
+Array [
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "job",
+      },
+      "name": "test-job-test-c8bf5102",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "template": Object {
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "args": Array [
+                "--foo",
+                "bar",
+              ],
+              "command": Array [
+                "/bin/sh",
+                "-c",
+                "echo hello",
+              ],
+              "env": Array [
+                Object {
+                  "name": "FOO",
+                  "value": "bar",
+                },
+              ],
+              "envFrom": Array [
+                Object {
+                  "configMapRef": Object {
+                    "name": "foo-config",
+                  },
+                },
+              ],
+              "image": "talis/app:worker-v1",
+              "imagePullPolicy": "Always",
+              "name": "my-app",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": 1,
+                  "memory": "1Gi",
+                },
+                "requests": Object {
+                  "cpu": 0.1,
+                  "memory": "100Mi",
+                },
+              },
+              "securityContext": Object {
+                "runAsGroup": 1000,
+                "runAsNonRoot": true,
+                "runAsUser": 1000,
+              },
+              "workingDir": "/some/path",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`Job Props Minimal required props 1`] = `
+Array [
+  Object {
+    "apiVersion": "batch/v1",
+    "kind": "Job",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "job-test",
+        "release": "v1",
+        "role": "job",
+      },
+      "name": "test-job-test-c8bf5102",
+    },
+    "spec": Object {
+      "template": Object {
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "image": "talis/app:worker-v1",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "app",
+              "resources": Object {
+                "requests": Object {
+                  "cpu": "100m",
+                  "memory": "100Mi",
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;

--- a/test/job/job.test.ts
+++ b/test/job/job.test.ts
@@ -1,0 +1,148 @@
+import { Chart, Testing } from "cdk8s";
+import { Quantity } from "../../imports/k8s";
+import { Job, JobProps } from "../../lib";
+
+const requiredProps = {
+  image: "talis/app:worker-v1",
+  release: "v1",
+  resources: {
+    requests: {
+      cpu: Quantity.fromString("100m"),
+      memory: Quantity.fromString("100Mi"),
+    },
+  },
+};
+
+function synthJob(props: JobProps = requiredProps) {
+  const chart = Testing.chart();
+  new Job(chart, "job-test", props);
+  const results = Testing.synth(chart);
+  return results;
+}
+
+describe("Job", () => {
+  describe("Props", () => {
+    test("Minimal required props", () => {
+      const chart = Testing.chart();
+      new Job(chart, "job-test", requiredProps);
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("All the props", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        namespace: "test",
+        labels: {
+          app: "my-app",
+          environment: "test",
+          region: "local",
+        },
+      });
+      const selectorLabels = {
+        app: "my-app",
+        role: "job",
+        instance: "test",
+      };
+      new Job(chart, "job-test", {
+        ...requiredProps,
+        selectorLabels,
+        workingDir: "/some/path",
+        command: ["/bin/sh", "-c", "echo hello"],
+        args: ["--foo", "bar"],
+        env: [{ name: "FOO", value: "bar" }],
+        envFrom: [{ configMapRef: { name: "foo-config" } }],
+        imagePullPolicy: "Always",
+        resources: {
+          requests: {
+            cpu: Quantity.fromNumber(0.1),
+            memory: Quantity.fromString("100Mi"),
+          },
+          limits: {
+            cpu: Quantity.fromNumber(1),
+            memory: Quantity.fromString("1Gi"),
+          },
+        },
+        securityContext: {
+          runAsUser: 1000,
+          runAsGroup: 1000,
+          runAsNonRoot: true,
+        },
+        lifecycle: {
+          postStart: {
+            exec: {
+              command: ["/bin/sh", "-c", "echo hello"],
+            },
+          },
+          preStop: {
+            exec: {
+              command: ["/bin/sh", "-c", "echo goodbye"],
+            },
+          },
+        },
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Container name", () => {
+    test("Default container name", () => {
+      const results = synthJob();
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "app"
+      );
+    });
+
+    test("Container name from chart's app label", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        labels: {
+          app: "from-chart",
+        },
+      });
+      new Job(chart, "worker-test", requiredProps);
+      const results = Testing.synth(chart);
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-chart"
+      );
+    });
+
+    test("Container name from selector label", () => {
+      const results = synthJob({
+        ...requiredProps,
+        selectorLabels: { app: "from-selector" },
+      });
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "from-selector"
+      );
+    });
+
+    test("Container name set explicitly", () => {
+      const results = synthJob({
+        ...requiredProps,
+        containerName: "explicit-name",
+      });
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].name",
+        "explicit-name"
+      );
+    });
+
+    test("ttlSecondsAfterFinished set explicitly", () => {
+      const results = synthJob({
+        ...requiredProps,
+        ttlSecondsAfterFinished: 100,
+      });
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty("spec.ttlSecondsAfterFinished", 100);
+    });
+  });
+});


### PR DESCRIPTION
- This relates to talis/platform#5461

This P/R adds a new cdk8s construct that represents a single run Job which can be  used to complete tasks such as seeding data in a database.

- [x] adds a new `Job` construct, and tests.
- [x] adds examples and docs