### PR TITLE
feat: adds redis construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
   - The command to run is defined as part of the container spec.
   - Details in an [example](./examples/job/README.md).
 
+- `Redis`
+
+  - Represents a standalone singe node Redis server.
+  - The command to run is defined as part of the container spec.
+  - Supports setting the version of redis you wish to run.
+  - Uses the default redis-server config.
+  - Details in an [example](./examples/redis/README.md).
+
 - `Secret`
 
   - Represents a Kubernetes Secret.

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,25 @@
+# Redis construct example
+
+Demonstrates running a redis server.
+
+## Usage
+
+In order to synthesize the example to Kubernetes YAML, you need to run the following command:
+
+```sh
+npx cdk8s synth
+```
+
+This will produce `dist/app.k8s.yaml` file which you can then apply to your cluster:
+
+```sh
+kubectl apply -f dist/app.k8s.yaml
+```
+
+## Testing
+
+You can run the tests with the following command:
+
+```sh
+npm test -- examples/redis
+```

--- a/examples/redis/__snapshots__/chart.test.ts.snap
+++ b/examples/redis/__snapshots__/chart.test.ts.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redis example Snapshot 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-redis-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-redis-app-development-local",
+      },
+      "name": "example-redis-app-test",
+      "namespace": "example-redis-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-redis-app",
+        "environment": "development",
+        "instance": "redis-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "redis",
+        "service": "example-redis-app-development-local",
+      },
+      "name": "redis-example",
+      "namespace": "example-redis-app-test",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 6379,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "app": "example-redis-app",
+        "instance": "redis-example",
+        "role": "redis",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-redis-app",
+        "environment": "development",
+        "instance": "redis-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "redis",
+        "service": "example-redis-app-development-local",
+      },
+      "name": "redis-example-sts",
+      "namespace": "example-redis-app-test",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "example-redis-app",
+          "instance": "redis-example",
+          "role": "redis",
+        },
+      },
+      "serviceName": "redis-example",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "example-redis-app",
+            "instance": "redis-example",
+            "role": "redis",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "redis-server",
+                "--appendonly",
+                "yes",
+              ],
+              "env": Array [
+                Object {
+                  "name": "MASTER",
+                  "value": "true",
+                },
+              ],
+              "image": "redis:v1.0",
+              "name": "redis",
+              "ports": Array [
+                Object {
+                  "containerPort": 6379,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "250Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/redis-master-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;

--- a/examples/redis/__snapshots__/chart.test.ts.snap
+++ b/examples/redis/__snapshots__/chart.test.ts.snap
@@ -27,7 +27,7 @@ Array [
         "instance": "redis-example",
         "managed-by": "cdk8s",
         "region": "local",
-        "release": "v1.0",
+        "release": "5.0.7",
         "role": "redis",
         "service": "example-redis-app-development-local",
       },
@@ -58,7 +58,7 @@ Array [
         "instance": "redis-example",
         "managed-by": "cdk8s",
         "region": "local",
-        "release": "v1.0",
+        "release": "5.0.7",
         "role": "redis",
         "service": "example-redis-app-development-local",
       },
@@ -97,7 +97,7 @@ Array [
                   "value": "true",
                 },
               ],
-              "image": "redis:v1.0",
+              "image": "redis:5.0.7",
               "name": "redis",
               "ports": Array [
                 Object {

--- a/examples/redis/cdk8s.yaml
+++ b/examples/redis/cdk8s.yaml
@@ -1,0 +1,2 @@
+language: typescript
+app: ts-node main.ts

--- a/examples/redis/chart.test.ts
+++ b/examples/redis/chart.test.ts
@@ -1,0 +1,29 @@
+import { RedisChart } from "./chart";
+import { Testing } from "cdk8s";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+describe("Redis example", () => {
+  const PROCESS_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...PROCESS_ENV };
+    process.env.DOCKER_USERNAME = "someuser";
+    process.env.DOCKER_PASSWORD = "secret123";
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV;
+  });
+
+  test("Snapshot", () => {
+    const app = Testing.app();
+    const chart = new RedisChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/examples/redis/chart.test.ts
+++ b/examples/redis/chart.test.ts
@@ -3,17 +3,8 @@ import { Testing } from "cdk8s";
 import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
 
 describe("Redis example", () => {
-  const PROCESS_ENV = process.env;
-
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...PROCESS_ENV };
-    process.env.DOCKER_USERNAME = "someuser";
-    process.env.DOCKER_PASSWORD = "secret123";
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV;
   });
 
   test("Snapshot", () => {

--- a/examples/redis/chart.ts
+++ b/examples/redis/chart.ts
@@ -6,7 +6,7 @@ export class RedisChart extends TalisChart {
     super(scope, { app: "example-redis-app", ...props });
 
     new Redis(this, "redis-example", {
-      release: "v1.0",
+      release: "5.0.7",
     });
   }
 }

--- a/examples/redis/chart.ts
+++ b/examples/redis/chart.ts
@@ -1,0 +1,12 @@
+import { Construct } from "constructs";
+import { Redis, TalisChart, TalisChartProps } from "../../lib";
+
+export class RedisChart extends TalisChart {
+  constructor(scope: Construct, props: TalisChartProps) {
+    super(scope, { app: "example-redis-app", ...props });
+
+    new Redis(this, "redis-example", {
+      release: "v1.0",
+    });
+  }
+}

--- a/examples/redis/main.ts
+++ b/examples/redis/main.ts
@@ -1,0 +1,11 @@
+import { App } from "cdk8s";
+import { RedisChart } from "./chart";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+const app = new App();
+new RedisChart(app, {
+  environment: TalisDeploymentEnvironment.DEVELOPMENT,
+  region: TalisShortRegion.LOCAL,
+  watermark: "example",
+});
+app.synth();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,5 +2,6 @@ export * from "./cron-job";
 export * from "./background-worker";
 export * from "./data";
 export * from "./job";
+export * from "./redis";
 export * from "./talis-chart";
 export * from "./web-service";

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -1,0 +1,2 @@
+export * from "./redis-props";
+export * from "./redis";

--- a/lib/redis/redis-props.ts
+++ b/lib/redis/redis-props.ts
@@ -1,0 +1,11 @@
+export interface RedisProps {
+  /**
+   * Custom selector labels, they will be merged with the default app, role, and instance.
+   * They will be applied to the workload, the pod and the service.
+   * @default { app: "<app label from chart>", role: "redis", instance: "<construct id>" }
+   */
+  readonly selectorLabels?: { [key: string]: string };
+
+  /** Release version of the Docker image. */
+  readonly release: string;
+}

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -1,0 +1,101 @@
+import { Chart } from "cdk8s";
+import { Construct } from "constructs";
+import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
+import { RedisProps } from "./redis-props";
+
+export class Redis extends Construct {
+  constructor(scope: Construct, id: string, props: RedisProps) {
+    super(scope, id);
+
+    const chart = Chart.of(this);
+    const app = chart.labels.app ?? props.selectorLabels?.app;
+    const release = props.release ?? "5.0.7";
+    const labels = {
+      ...chart.labels,
+      release: release,
+    };
+
+    const selectorLabels: { [key: string]: string } = {
+      app: app,
+      role: "redis",
+      instance: id,
+      ...props.selectorLabels,
+    };
+
+    const instanceLabels: { [key: string]: string } = {
+      ...labels,
+      ...selectorLabels,
+    };
+
+    const service = new KubeService(this, id, {
+      metadata: {
+        labels: instanceLabels,
+      },
+      spec: {
+        ports: [
+          {
+            port: 6379,
+            protocol: "TCP",
+          },
+        ],
+        selector: selectorLabels,
+      },
+    });
+
+    new KubeStatefulSet(this, `${id}-sts`, {
+      metadata: {
+        labels: instanceLabels,
+      },
+      spec: {
+        serviceName: service.name,
+        replicas: 1,
+        selector: {
+          matchLabels: selectorLabels,
+        },
+        template: {
+          metadata: {
+            labels: selectorLabels,
+          },
+          spec: {
+            volumes: [
+              {
+                name: "data",
+                emptyDir: {},
+              },
+            ],
+            containers: [
+              {
+                name: "redis",
+                image: `redis:${release}`,
+                command: ["redis-server", "--appendonly", "yes"],
+                env: [
+                  {
+                    name: "MASTER",
+                    value: "true",
+                  },
+                ],
+                ports: [
+                  {
+                    containerPort: 6379,
+                  },
+                ],
+                resources: {
+                  limits: {
+                    cpu: Quantity.fromString("100m"),
+                    memory: Quantity.fromString("250Mb"),
+                  },
+                },
+                volumeMounts: [
+                  {
+                    mountPath: "/redis-master-data",
+                    name: "data",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+  }
+}

--- a/test/redis/__snapshots__/redis.test.ts.snap
+++ b/test/redis/__snapshots__/redis.test.ts.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Redis Props All the props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "redis",
+      },
+      "name": "test-redis-test-c8b56c58",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 6379,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "app": "my-app",
+        "instance": "test",
+        "role": "redis",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "redis",
+      },
+      "name": "test-redis-test-redis-test-sts-c82d6e34",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "my-app",
+          "instance": "test",
+          "role": "redis",
+        },
+      },
+      "serviceName": "test-redis-test-c8b56c58",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "my-app",
+            "instance": "test",
+            "role": "redis",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "redis-server",
+                "--appendonly",
+                "yes",
+              ],
+              "env": Array [
+                Object {
+                  "name": "MASTER",
+                  "value": "true",
+                },
+              ],
+              "image": "redis:v1",
+              "name": "redis",
+              "ports": Array [
+                Object {
+                  "containerPort": 6379,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "250Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/redis-master-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`Redis Props Minimal required props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "redis-test",
+        "release": "v1",
+        "role": "redis",
+      },
+      "name": "test-redis-test-c8b56c58",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 6379,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "instance": "redis-test",
+        "role": "redis",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "redis-test",
+        "release": "v1",
+        "role": "redis",
+      },
+      "name": "test-redis-test-redis-test-sts-c82d6e34",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "instance": "redis-test",
+          "role": "redis",
+        },
+      },
+      "serviceName": "test-redis-test-c8b56c58",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "instance": "redis-test",
+            "role": "redis",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "redis-server",
+                "--appendonly",
+                "yes",
+              ],
+              "env": Array [
+                Object {
+                  "name": "MASTER",
+                  "value": "true",
+                },
+              ],
+              "image": "redis:v1",
+              "name": "redis",
+              "ports": Array [
+                Object {
+                  "containerPort": 6379,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "250Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/redis-master-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -1,0 +1,71 @@
+import { Chart, Testing } from "cdk8s";
+import { Redis, RedisProps } from "../../lib";
+
+const requiredProps = {
+  release: "v1",
+};
+
+function synthRedis(props: RedisProps = requiredProps) {
+  const chart = Testing.chart();
+  new Redis(chart, "redis-test", props);
+  const results = Testing.synth(chart);
+  return results;
+}
+
+describe("Redis", () => {
+  describe("Props", () => {
+    test("Minimal required props", () => {
+      const chart = Testing.chart();
+      new Redis(chart, "redis-test", requiredProps);
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("All the props", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        namespace: "test",
+        labels: {
+          app: "my-app",
+          environment: "test",
+          region: "local",
+        },
+      });
+      const selectorLabels = {
+        app: "my-app",
+        role: "redis",
+        instance: "test",
+      };
+
+      new Redis(chart, "redis-test", {
+        ...requiredProps,
+        selectorLabels,
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Container release", () => {
+    test("Default container release", () => {
+      const results = synthRedis();
+      const job = results.find((obj) => obj.kind === "StatefulSet");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].image",
+        "redis:v1"
+      );
+    });
+
+    test("Container release set explicitly", () => {
+      const results = synthRedis({
+        ...requiredProps,
+        release: "12345",
+      });
+      const job = results.find((obj) => obj.kind === "StatefulSet");
+      expect(job).toHaveProperty(
+        "spec.template.spec.containers[0].image",
+        "redis:12345"
+      );
+    });
+  });
+});


### PR DESCRIPTION
- This relates to talis/platform#5463

This P/R adds a new cdk8s construct that represents a simple single node redis service. This is not intended to be used as a production service (we have elastic cache for that) but rather for on demand instances.

- [x] adds a new `Redis` construct, and tests.
- [x] adds examples and docs