### PR TITLE
feat: adds mongo construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
   - The command to run is defined as part of the container spec.
   - Details in an [example](./examples/job/README.md).
 
+- `Mongo`
+
+  - Represents a standalone single node Mongo server.
+  - The command to run is defined as part of the container spec.
+  - Supports setting the version of Mongo you wish to run.
+  - Supports setting the storageEngine.
+  - Details in an [example](./examples/mongo/README.md).
+
 - `Redis`
 
   - Represents a standalone singe node Redis server.

--- a/examples/mongo/README.md
+++ b/examples/mongo/README.md
@@ -1,0 +1,25 @@
+# Mongo construct example
+
+Demonstrates running a simple standalone Mongo server.
+
+## Usage
+
+In order to synthesize the example to Kubernetes YAML, you need to run the following command:
+
+```sh
+npx cdk8s synth
+```
+
+This will produce `dist/app.k8s.yaml` file which you can then apply to your cluster:
+
+```sh
+kubectl apply -f dist/app.k8s.yaml
+```
+
+## Testing
+
+You can run the tests with the following command:
+
+```sh
+npm test -- examples/mongo
+```

--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Mongo example Snapshot 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-mongo-app",
+        "environment": "development",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "service": "example-mongo-app-development-local",
+      },
+      "name": "example-mongo-app-test",
+      "namespace": "example-mongo-app-test",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-mongo-app",
+        "environment": "development",
+        "instance": "redis-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "mongo",
+        "service": "example-mongo-app-development-local",
+      },
+      "name": "redis-example",
+      "namespace": "example-mongo-app-test",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 27107,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "app": "example-mongo-app",
+        "instance": "redis-example",
+        "role": "mongo",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "app": "example-mongo-app",
+        "environment": "development",
+        "instance": "redis-example",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "release": "v1.0",
+        "role": "mongo",
+        "service": "example-mongo-app-development-local",
+      },
+      "name": "redis-example-sts",
+      "namespace": "example-mongo-app-test",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "example-mongo-app",
+          "instance": "redis-example",
+          "role": "mongo",
+        },
+      },
+      "serviceName": "redis-example",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "example-mongo-app",
+            "instance": "redis-example",
+            "role": "mongo",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "--smallfiles",
+                "--storageEngine",
+                "mmapv1",
+              ],
+              "image": "mongo:v1.0",
+              "name": "mongo",
+              "ports": Array [
+                Object {
+                  "containerPort": 27017,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "500Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/mongo-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;

--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -27,7 +27,7 @@ Array [
         "instance": "redis-example",
         "managed-by": "cdk8s",
         "region": "local",
-        "release": "v1.0",
+        "release": "3.2.8",
         "role": "mongo",
         "service": "example-mongo-app-development-local",
       },
@@ -58,7 +58,7 @@ Array [
         "instance": "redis-example",
         "managed-by": "cdk8s",
         "region": "local",
-        "release": "v1.0",
+        "release": "3.2.8",
         "role": "mongo",
         "service": "example-mongo-app-development-local",
       },
@@ -91,7 +91,7 @@ Array [
                 "--storageEngine",
                 "mmapv1",
               ],
-              "image": "mongo:v1.0",
+              "image": "mongo:3.2.8",
               "name": "mongo",
               "ports": Array [
                 Object {

--- a/examples/mongo/cdk8s.yaml
+++ b/examples/mongo/cdk8s.yaml
@@ -1,0 +1,2 @@
+language: typescript
+app: ts-node main.ts

--- a/examples/mongo/chart.test.ts
+++ b/examples/mongo/chart.test.ts
@@ -3,17 +3,8 @@ import { Testing } from "cdk8s";
 import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
 
 describe("Mongo example", () => {
-  const PROCESS_ENV = process.env;
-
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...PROCESS_ENV };
-    process.env.DOCKER_USERNAME = "someuser";
-    process.env.DOCKER_PASSWORD = "secret123";
-  });
-
-  afterEach(() => {
-    process.env = PROCESS_ENV;
   });
 
   test("Snapshot", () => {

--- a/examples/mongo/chart.test.ts
+++ b/examples/mongo/chart.test.ts
@@ -1,0 +1,29 @@
+import { MongoChart } from "./chart";
+import { Testing } from "cdk8s";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+describe("Mongo example", () => {
+  const PROCESS_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...PROCESS_ENV };
+    process.env.DOCKER_USERNAME = "someuser";
+    process.env.DOCKER_PASSWORD = "secret123";
+  });
+
+  afterEach(() => {
+    process.env = PROCESS_ENV;
+  });
+
+  test("Snapshot", () => {
+    const app = Testing.app();
+    const chart = new MongoChart(app, {
+      environment: TalisDeploymentEnvironment.DEVELOPMENT,
+      region: TalisShortRegion.LOCAL,
+      watermark: "test",
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+});

--- a/examples/mongo/chart.ts
+++ b/examples/mongo/chart.ts
@@ -1,0 +1,12 @@
+import { Construct } from "constructs";
+import { Mongo, TalisChart, TalisChartProps } from "../../lib";
+
+export class MongoChart extends TalisChart {
+  constructor(scope: Construct, props: TalisChartProps) {
+    super(scope, { app: "example-mongo-app", ...props });
+
+    new Mongo(this, "redis-example", {
+      release: "v1.0",
+    });
+  }
+}

--- a/examples/mongo/chart.ts
+++ b/examples/mongo/chart.ts
@@ -6,7 +6,7 @@ export class MongoChart extends TalisChart {
     super(scope, { app: "example-mongo-app", ...props });
 
     new Mongo(this, "redis-example", {
-      release: "v1.0",
+      release: "3.2.8",
     });
   }
 }

--- a/examples/mongo/main.ts
+++ b/examples/mongo/main.ts
@@ -1,0 +1,11 @@
+import { App } from "cdk8s";
+import { MongoChart } from "./chart";
+import { TalisShortRegion, TalisDeploymentEnvironment } from "../../lib";
+
+const app = new App();
+new MongoChart(app, {
+  environment: TalisDeploymentEnvironment.DEVELOPMENT,
+  region: TalisShortRegion.LOCAL,
+  watermark: "example",
+});
+app.synth();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ export * from "./cron-job";
 export * from "./background-worker";
 export * from "./data";
 export * from "./job";
+export * from "./mongo";
 export * from "./redis";
 export * from "./talis-chart";
 export * from "./web-service";

--- a/lib/mongo/index.ts
+++ b/lib/mongo/index.ts
@@ -1,0 +1,2 @@
+export * from "./mongo-props";
+export * from "./mongo";

--- a/lib/mongo/mongo-props.ts
+++ b/lib/mongo/mongo-props.ts
@@ -1,0 +1,17 @@
+export interface MongoProps {
+  /**
+   * Custom selector labels, they will be merged with the default app, role, and instance.
+   * They will be applied to the workload, the pod and the service.
+   * @default { app: "<app label from chart>", role: "cronjob", instance: "<construct id>" }
+   */
+  readonly selectorLabels?: { [key: string]: string };
+
+  /** Release version of the Docker image. */
+  readonly release: string;
+
+  /**
+   * The storage engine to use
+   * @default mmapv1
+   */
+  readonly storageEngine?: "wiredTiger" | "inMemory" | "mmapv1";
+}

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -1,0 +1,96 @@
+import { Chart } from "cdk8s";
+import { Construct } from "constructs";
+import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
+import { MongoProps } from "./mongo-props";
+
+export class Mongo extends Construct {
+  constructor(scope: Construct, id: string, props: MongoProps) {
+    super(scope, id);
+
+    const chart = Chart.of(this);
+    const app = chart.labels.app ?? props.selectorLabels?.app;
+    const release = props.release ?? "3.2.8";
+    const storageEngine = props.storageEngine ?? "mmapv1";
+    const labels = {
+      ...chart.labels,
+      release: release,
+    };
+
+    const selectorLabels: { [key: string]: string } = {
+      app: app,
+      role: "mongo",
+      instance: id,
+      ...props.selectorLabels,
+    };
+
+    const instanceLabels: { [key: string]: string } = {
+      ...labels,
+      ...selectorLabels,
+    };
+
+    const service = new KubeService(this, id, {
+      metadata: {
+        labels: instanceLabels,
+      },
+      spec: {
+        ports: [
+          {
+            port: 27107,
+            protocol: "TCP",
+          },
+        ],
+        selector: selectorLabels,
+      },
+    });
+
+    new KubeStatefulSet(this, `${id}-sts`, {
+      metadata: {
+        labels: instanceLabels,
+      },
+      spec: {
+        serviceName: service.name,
+        replicas: 1,
+        selector: {
+          matchLabels: selectorLabels,
+        },
+        template: {
+          metadata: {
+            labels: selectorLabels,
+          },
+          spec: {
+            volumes: [
+              {
+                name: "data",
+                emptyDir: {},
+              },
+            ],
+            containers: [
+              {
+                name: "mongo",
+                image: `mongo:${release}`,
+                command: ["--smallfiles", "--storageEngine", storageEngine],
+                ports: [
+                  {
+                    containerPort: 27017,
+                  },
+                ],
+                resources: {
+                  limits: {
+                    cpu: Quantity.fromString("100m"),
+                    memory: Quantity.fromString("500Mb"),
+                  },
+                },
+                volumeMounts: [
+                  {
+                    mountPath: "/mongo-data",
+                    name: "data",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+  }
+}

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -1,0 +1,202 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Mongo Props All the props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "mongo",
+      },
+      "name": "test-mongo-test-c844268f",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 27107,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "app": "my-app",
+        "instance": "test",
+        "role": "mongo",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "app": "my-app",
+        "environment": "test",
+        "instance": "test",
+        "region": "local",
+        "release": "v1",
+        "role": "mongo",
+      },
+      "name": "test-mongo-test-mongo-test-sts-c8cbd639",
+      "namespace": "test",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "app": "my-app",
+          "instance": "test",
+          "role": "mongo",
+        },
+      },
+      "serviceName": "test-mongo-test-c844268f",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "app": "my-app",
+            "instance": "test",
+            "role": "mongo",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "--smallfiles",
+                "--storageEngine",
+                "mmapv1",
+              ],
+              "image": "mongo:v1",
+              "name": "mongo",
+              "ports": Array [
+                Object {
+                  "containerPort": 27017,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "500Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/mongo-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`Mongo Props Minimal required props 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "mongo-test",
+        "release": "v1",
+        "role": "mongo",
+      },
+      "name": "test-mongo-test-c844268f",
+    },
+    "spec": Object {
+      "ports": Array [
+        Object {
+          "port": 27107,
+          "protocol": "TCP",
+        },
+      ],
+      "selector": Object {
+        "instance": "mongo-test",
+        "role": "mongo",
+      },
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": Object {
+      "labels": Object {
+        "instance": "mongo-test",
+        "release": "v1",
+        "role": "mongo",
+      },
+      "name": "test-mongo-test-mongo-test-sts-c8cbd639",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "instance": "mongo-test",
+          "role": "mongo",
+        },
+      },
+      "serviceName": "test-mongo-test-c844268f",
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "instance": "mongo-test",
+            "role": "mongo",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "command": Array [
+                "--smallfiles",
+                "--storageEngine",
+                "mmapv1",
+              ],
+              "image": "mongo:v1",
+              "name": "mongo",
+              "ports": Array [
+                Object {
+                  "containerPort": 27017,
+                },
+              ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "100m",
+                  "memory": "500Mb",
+                },
+              },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/mongo-data",
+                  "name": "data",
+                },
+              ],
+            },
+          ],
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "data",
+            },
+          ],
+        },
+      },
+    },
+  },
+]
+`;

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -1,0 +1,98 @@
+import { Chart, Testing } from "cdk8s";
+import { Mongo, MongoProps } from "../../lib";
+
+const requiredProps = {
+  release: "v1",
+};
+
+function synthMongo(props: MongoProps = requiredProps) {
+  const chart = Testing.chart();
+  new Mongo(chart, "mongo-test", props);
+  const results = Testing.synth(chart);
+  return results;
+}
+
+describe("Mongo", () => {
+  describe("Props", () => {
+    test("Minimal required props", () => {
+      const chart = Testing.chart();
+      new Mongo(chart, "mongo-test", requiredProps);
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
+    test("All the props", () => {
+      const app = Testing.app();
+      const chart = new Chart(app, "test", {
+        namespace: "test",
+        labels: {
+          app: "my-app",
+          environment: "test",
+          region: "local",
+        },
+      });
+      const selectorLabels = {
+        app: "my-app",
+        role: "mongo",
+        instance: "test",
+      };
+
+      new Mongo(chart, "mongo-test", {
+        ...requiredProps,
+        selectorLabels,
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Container release", () => {
+    test("Default container release", () => {
+      const results = synthMongo();
+      const mongo = results.find((obj) => obj.kind === "StatefulSet");
+      expect(mongo).toHaveProperty(
+        "spec.template.spec.containers[0].image",
+        "mongo:v1"
+      );
+    });
+
+    test("Container release set explicitly", () => {
+      const results = synthMongo({
+        ...requiredProps,
+        release: "12345",
+      });
+      const mongo = results.find((obj) => obj.kind === "StatefulSet");
+      expect(mongo).toHaveProperty(
+        "spec.template.spec.containers[0].image",
+        "mongo:12345"
+      );
+    });
+  });
+
+  describe("Storage Engine", () => {
+    test("Default storage engine", () => {
+      const results = synthMongo({
+        ...requiredProps,
+      });
+      const mongo = results.find((obj) => obj.kind === "StatefulSet");
+      expect(mongo).toHaveProperty("spec.template.spec.containers[0].command", [
+        "--smallfiles",
+        "--storageEngine",
+        "mmapv1",
+      ]);
+    });
+
+    test("Storage engine set explicitly", () => {
+      const results = synthMongo({
+        ...requiredProps,
+        storageEngine: "wiredTiger",
+      });
+      const mongo = results.find((obj) => obj.kind === "StatefulSet");
+      expect(mongo).toHaveProperty("spec.template.spec.containers[0].command", [
+        "--smallfiles",
+        "--storageEngine",
+        "wiredTiger",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
- This relates to talis/platform#5462

This P/R adds a new cdk8s construct that represents a simple single node Mongo service. This is not intended to be used as a production service but rather for on demand instances.

- [x] adds a new `Mongo` construct, and tests.
- [x] adds examples and docs