### PR TITLE
feat: add restartPolicy and backoffLimit

### DIFF
--- a/examples/cron-job/__snapshots__/chart.test.ts.snap
+++ b/examples/cron-job/__snapshots__/chart.test.ts.snap
@@ -56,6 +56,7 @@ Array [
     "spec": Object {
       "jobTemplate": Object {
         "spec": Object {
+          "backoffLimit": 6,
           "template": Object {
             "spec": Object {
               "containers": Array [
@@ -77,6 +78,7 @@ Array [
                   "workingDir": "/some/path",
                 },
               ],
+              "restartPolicy": "Never",
             },
           },
         },
@@ -143,6 +145,7 @@ Array [
     "spec": Object {
       "jobTemplate": Object {
         "spec": Object {
+          "backoffLimit": 6,
           "template": Object {
             "spec": Object {
               "containers": Array [
@@ -164,6 +167,7 @@ Array [
                   "workingDir": "/some/path",
                 },
               ],
+              "restartPolicy": "Never",
             },
           },
         },

--- a/examples/cron-job/chart.ts
+++ b/examples/cron-job/chart.ts
@@ -17,6 +17,7 @@ export class CronJobChart extends TalisChart {
 
     new CronJob(this, "cron-job-example", {
       schedule: "0 0 13 * 5",
+      restartPolicy: "Never",
       image: `docker.io/organization/my-app:cron-${release}`,
       imagePullSecrets: [{ name: dockerHubSecret.name }],
       release,

--- a/examples/job/__snapshots__/chart.test.ts.snap
+++ b/examples/job/__snapshots__/chart.test.ts.snap
@@ -54,6 +54,7 @@ Array [
       "namespace": "example-job-app-test",
     },
     "spec": Object {
+      "backoffLimit": 6,
       "template": Object {
         "spec": Object {
           "containers": Array [
@@ -75,6 +76,7 @@ Array [
               "workingDir": "/some/path",
             },
           ],
+          "restartPolicy": "OnFailure",
         },
       },
       "ttlSecondsAfterFinished": 100,
@@ -137,6 +139,7 @@ Array [
       "namespace": "example-job-app-test",
     },
     "spec": Object {
+      "backoffLimit": 6,
       "template": Object {
         "spec": Object {
           "containers": Array [
@@ -158,6 +161,7 @@ Array [
               "workingDir": "/some/path",
             },
           ],
+          "restartPolicy": "OnFailure",
         },
       },
       "ttlSecondsAfterFinished": 100,

--- a/examples/job/chart.ts
+++ b/examples/job/chart.ts
@@ -16,6 +16,7 @@ export class JobChart extends TalisChart {
     const dockerHubSecret = createDockerHubSecretFromEnv(this);
 
     new Job(this, "job-example", {
+      restartPolicy: "OnFailure",
       ttlSecondsAfterFinished: 100,
       image: `docker.io/organization/my-app:job-${release}`,
       imagePullSecrets: [{ name: dockerHubSecret.name }],

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -22,4 +22,15 @@ export interface CronJobProps
    * list of volumes that can be mounted by containers belonging to the pod.
    */
   readonly volumes?: Volume[];
+
+  /**
+   * Restart policy for all containers within the pod.
+   */
+  readonly restartPolicy: "OnFailure" | "Never";
+
+  /**
+   * Specifies the number of retries before marking this job failed.
+   * @default 6
+   */
+  readonly backoffLimit?: number;
 }

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -30,9 +30,11 @@ export class CronJob extends Construct {
         schedule: props.schedule,
         jobTemplate: {
           spec: {
+            backoffLimit: props.backoffLimit ?? 6,
             template: {
               spec: {
                 volumes: props.volumes,
+                restartPolicy: props.restartPolicy,
                 initContainers: props.initContainers,
                 containers: [
                   {

--- a/lib/job/job-props.ts
+++ b/lib/job/job-props.ts
@@ -21,6 +21,17 @@ export interface JobProps
   readonly volumes?: Volume[];
 
   /**
+   * Restart policy for all containers within the pod.
+   */
+  readonly restartPolicy: "OnFailure" | "Never";
+
+  /**
+   * Specifies the number of retries before marking this job failed.
+   * @default 6
+   */
+  readonly backoffLimit?: number;
+
+  /**
    * ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete
    * or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible
    * to be automatically deleted. When the Job is being deleted, its lifecycle guarantees

--- a/lib/job/job.ts
+++ b/lib/job/job.ts
@@ -26,10 +26,12 @@ export class Job extends Construct {
         labels: { ...labels, ...selectorLabels },
       },
       spec: {
+        backoffLimit: props.backoffLimit ?? 6,
         ttlSecondsAfterFinished: props.ttlSecondsAfterFinished,
         template: {
           spec: {
             volumes: props.volumes,
+            restartPolicy: props.restartPolicy,
             initContainers: props.initContainers,
             containers: [
               {

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -4,6 +4,8 @@ import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
 import { MongoProps } from "./mongo-props";
 
 export class Mongo extends Construct {
+  readonly service: KubeService;
+
   constructor(scope: Construct, id: string, props: MongoProps) {
     super(scope, id);
 
@@ -28,7 +30,7 @@ export class Mongo extends Construct {
       ...selectorLabels,
     };
 
-    const service = new KubeService(this, id, {
+    this.service = new KubeService(this, id, {
       metadata: {
         labels: instanceLabels,
       },
@@ -48,7 +50,7 @@ export class Mongo extends Construct {
         labels: instanceLabels,
       },
       spec: {
-        serviceName: service.name,
+        serviceName: this.service.name,
         replicas: 1,
         selector: {
           matchLabels: selectorLabels,

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -4,6 +4,8 @@ import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
 import { RedisProps } from "./redis-props";
 
 export class Redis extends Construct {
+  readonly service: KubeService;
+
   constructor(scope: Construct, id: string, props: RedisProps) {
     super(scope, id);
 
@@ -27,7 +29,7 @@ export class Redis extends Construct {
       ...selectorLabels,
     };
 
-    const service = new KubeService(this, id, {
+    this.service = new KubeService(this, id, {
       metadata: {
         labels: instanceLabels,
       },
@@ -47,7 +49,7 @@ export class Redis extends Construct {
         labels: instanceLabels,
       },
       spec: {
-        serviceName: service.name,
+        serviceName: this.service.name,
         replicas: 1,
         selector: {
           matchLabels: selectorLabels,

--- a/test/cron-job/__snapshots__/cron-job.test.ts.snap
+++ b/test/cron-job/__snapshots__/cron-job.test.ts.snap
@@ -20,6 +20,7 @@ Array [
     "spec": Object {
       "jobTemplate": Object {
         "spec": Object {
+          "backoffLimit": 2,
           "template": Object {
             "spec": Object {
               "containers": Array [
@@ -78,6 +79,7 @@ Array [
                   "name": "init-container",
                 },
               ],
+              "restartPolicy": "OnFailure",
             },
           },
         },
@@ -104,6 +106,7 @@ Array [
     "spec": Object {
       "jobTemplate": Object {
         "spec": Object {
+          "backoffLimit": 2,
           "template": Object {
             "spec": Object {
               "containers": Array [
@@ -119,6 +122,7 @@ Array [
                   },
                 },
               ],
+              "restartPolicy": "OnFailure",
             },
           },
         },

--- a/test/data/config-map.test.ts
+++ b/test/data/config-map.test.ts
@@ -2,15 +2,7 @@ import mockFs from "mock-fs";
 import { Lazy, Testing } from "cdk8s";
 import { ConfigMap } from "../../lib";
 import { KubePod } from "../../imports/k8s";
-
-function makeChart() {
-  const chart = Testing.chart();
-  // Just output node's id as the object's name
-  chart.generateObjectName = (obj) => {
-    return obj.node.id;
-  };
-  return chart;
-}
+import { makeChart } from "../test-util";
 
 describe("ConfigMap", () => {
   afterEach(() => {

--- a/test/data/secret.test.ts
+++ b/test/data/secret.test.ts
@@ -2,15 +2,7 @@ import mockFs from "mock-fs";
 import { Lazy, Testing } from "cdk8s";
 import { Secret } from "../../lib";
 import { KubePod } from "../../imports/k8s";
-
-function makeChart() {
-  const chart = Testing.chart();
-  // Just output node's id as the object's name
-  chart.generateObjectName = (obj) => {
-    return obj.node.id;
-  };
-  return chart;
-}
+import { makeChart } from "../test-util";
 
 describe("Secret", () => {
   describe("Props", () => {

--- a/test/job/__snapshots__/job.test.ts.snap
+++ b/test/job/__snapshots__/job.test.ts.snap
@@ -18,6 +18,7 @@ Array [
       "namespace": "test",
     },
     "spec": Object {
+      "backoffLimit": 0,
       "template": Object {
         "spec": Object {
           "containers": Array [
@@ -76,6 +77,7 @@ Array [
               "name": "init-container",
             },
           ],
+          "restartPolicy": "Never",
         },
       },
     },
@@ -97,6 +99,7 @@ Array [
       "name": "test-job-test-c8bf5102",
     },
     "spec": Object {
+      "backoffLimit": 0,
       "template": Object {
         "spec": Object {
           "containers": Array [
@@ -112,6 +115,7 @@ Array [
               },
             },
           ],
+          "restartPolicy": "Never",
         },
       },
     },

--- a/test/job/job.test.ts
+++ b/test/job/job.test.ts
@@ -2,7 +2,7 @@ import { Chart, Testing } from "cdk8s";
 import { Quantity } from "../../imports/k8s";
 import { Job, JobProps } from "../../lib";
 
-const requiredProps = {
+const requiredProps: JobProps = {
   image: "talis/app:worker-v1",
   release: "v1",
   resources: {
@@ -11,6 +11,8 @@ const requiredProps = {
       memory: Quantity.fromString("100Mi"),
     },
   },
+  backoffLimit: 0,
+  restartPolicy: "Never",
 };
 
 function synthJob(props: JobProps = requiredProps) {
@@ -90,6 +92,24 @@ describe("Job", () => {
       });
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+    });
+
+    test("Setting restartPolicy", () => {
+      const results = synthJob({
+        ...requiredProps,
+        restartPolicy: "Never",
+      });
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty("spec.template.spec.restartPolicy", "Never");
+    });
+
+    test("Setting backoffLimit", () => {
+      const results = synthJob({
+        ...requiredProps,
+        backoffLimit: 42,
+      });
+      const job = results.find((obj) => obj.kind === "Job");
+      expect(job).toHaveProperty("spec.backoffLimit", 42);
     });
   });
 

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -1,5 +1,7 @@
 import { Chart, Testing } from "cdk8s";
+import { KubeService } from "../../imports/k8s";
 import { Mongo, MongoProps } from "../../lib";
+import { makeChart } from "../test-util";
 
 const requiredProps = {
   release: "v1",
@@ -43,6 +45,16 @@ describe("Mongo", () => {
       });
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Service instance", () => {
+    test("Exposes service object through property", () => {
+      const chart = makeChart();
+      const mongo = new Mongo(chart, "mongo-test", requiredProps);
+      expect(mongo.service).toBeDefined();
+      expect(mongo.service).toBeInstanceOf(KubeService);
+      expect(mongo.service.name).toEqual("mongo-test");
     });
   });
 

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -1,5 +1,7 @@
 import { Chart, Testing } from "cdk8s";
+import { KubeService } from "../../imports/k8s";
 import { Redis, RedisProps } from "../../lib";
+import { makeChart } from "../test-util";
 
 const requiredProps = {
   release: "v1",
@@ -43,6 +45,16 @@ describe("Redis", () => {
       });
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+    });
+  });
+
+  describe("Service instance", () => {
+    test("Exposes service object through property", () => {
+      const chart = makeChart();
+      const redis = new Redis(chart, "redis-test", requiredProps);
+      expect(redis.service).toBeDefined();
+      expect(redis.service).toBeInstanceOf(KubeService);
+      expect(redis.service.name).toEqual("redis-test");
     });
   });
 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,0 +1,11 @@
+import { Chart, ChartProps, Testing } from "cdk8s";
+
+export function makeChart(props?: ChartProps) {
+  const app = Testing.app();
+  const chart = new Chart(app, "test", props);
+  // Just output node's id as the object's name
+  chart.generateObjectName = (obj) => {
+    return obj.node.id;
+  };
+  return chart;
+}

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -2,6 +2,7 @@ import { Chart, Testing } from "cdk8s";
 import { IntOrString, KubeConfigMap, Quantity } from "../../imports/k8s";
 import { WebService, WebServiceProps } from "../../lib";
 import * as _ from "lodash";
+import { makeChart } from "../test-util";
 
 const requiredProps = {
   description: "Test web service",
@@ -32,16 +33,10 @@ function synthWebService(
   props: WebServiceProps = defaultProps,
   chartLabels: { [key: string]: string } = {}
 ) {
-  const app = Testing.app();
-  const chart = new Chart(app, "test", {
+  const chart = makeChart({
     namespace: "test",
     labels: chartLabels,
   });
-
-  // Just output node's id as the object's name
-  chart.generateObjectName = (obj) => {
-    return obj.node.id;
-  };
 
   new WebService(chart, "web", props);
 


### PR DESCRIPTION
* Relates to https://github.com/talis/platform/issues/5482
* When trying to apply Job, it complained that `restartPolicy` is required.
* With `restartPolicy` exposed it also makes sense to expose `backoffLimit` prop.
* Allow to get Mongo's and Redis' service name from the object, so that we can reference it in the ConfigMaps when configuring on-demand chart.
