### PR TITLE
fix: correct memory units in Mongo and Redis

### DIFF
--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -101,7 +101,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "500Mb",
+                  "memory": "500Mi",
                 },
               },
               "volumeMounts": Array [

--- a/examples/redis/__snapshots__/chart.test.ts.snap
+++ b/examples/redis/__snapshots__/chart.test.ts.snap
@@ -107,7 +107,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "250Mb",
+                  "memory": "250Mi",
                 },
               },
               "volumeMounts": Array [

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -79,7 +79,7 @@ export class Mongo extends Construct {
                 resources: {
                   limits: {
                     cpu: Quantity.fromString("100m"),
-                    memory: Quantity.fromString("500Mb"),
+                    memory: Quantity.fromString("500Mi"),
                   },
                 },
                 volumeMounts: [

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -84,7 +84,7 @@ export class Redis extends Construct {
                 resources: {
                   limits: {
                     cpu: Quantity.fromString("100m"),
-                    memory: Quantity.fromString("250Mb"),
+                    memory: Quantity.fromString("250Mi"),
                   },
                 },
                 volumeMounts: [

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -82,7 +82,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "500Mb",
+                  "memory": "500Mi",
                 },
               },
               "volumeMounts": Array [
@@ -177,7 +177,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "500Mb",
+                  "memory": "500Mi",
                 },
               },
               "volumeMounts": Array [

--- a/test/redis/__snapshots__/redis.test.ts.snap
+++ b/test/redis/__snapshots__/redis.test.ts.snap
@@ -88,7 +88,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "250Mb",
+                  "memory": "250Mi",
                 },
               },
               "volumeMounts": Array [
@@ -189,7 +189,7 @@ Array [
               "resources": Object {
                 "limits": Object {
                   "cpu": "100m",
-                  "memory": "250Mb",
+                  "memory": "250Mi",
                 },
               },
               "volumeMounts": Array [


### PR DESCRIPTION
* `Mb` are not correct units, while applying I got error:
  > v1.ResourceRequirements.Limits: unmarshalerDecoder: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$', error found in#10 byte of ...|y":"500Mb"}}