### PR TITLE
fix: use args for Mongo rather than command

### DIFF
--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -86,7 +86,7 @@ Array [
         "spec": Object {
           "containers": Array [
             Object {
-              "command": Array [
+              "args": Array [
                 "--smallfiles",
                 "--storageEngine",
                 "mmapv1",

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -70,7 +70,7 @@ export class Mongo extends Construct {
               {
                 name: "mongo",
                 image: `mongo:${release}`,
-                command: ["--smallfiles", "--storageEngine", storageEngine],
+                args: ["--smallfiles", "--storageEngine", storageEngine],
                 ports: [
                   {
                     containerPort: 27017,

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -67,7 +67,7 @@ Array [
         "spec": Object {
           "containers": Array [
             Object {
-              "command": Array [
+              "args": Array [
                 "--smallfiles",
                 "--storageEngine",
                 "mmapv1",
@@ -162,7 +162,7 @@ Array [
         "spec": Object {
           "containers": Array [
             Object {
-              "command": Array [
+              "args": Array [
                 "--smallfiles",
                 "--storageEngine",
                 "mmapv1",

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -87,7 +87,7 @@ describe("Mongo", () => {
         ...requiredProps,
       });
       const mongo = results.find((obj) => obj.kind === "StatefulSet");
-      expect(mongo).toHaveProperty("spec.template.spec.containers[0].command", [
+      expect(mongo).toHaveProperty("spec.template.spec.containers[0].args", [
         "--smallfiles",
         "--storageEngine",
         "mmapv1",
@@ -100,7 +100,7 @@ describe("Mongo", () => {
         storageEngine: "wiredTiger",
       });
       const mongo = results.find((obj) => obj.kind === "StatefulSet");
-      expect(mongo).toHaveProperty("spec.template.spec.containers[0].command", [
+      expect(mongo).toHaveProperty("spec.template.spec.containers[0].args", [
         "--smallfiles",
         "--storageEngine",
         "wiredTiger",


### PR DESCRIPTION
Kubernetes uses `command` and `args` for defining how a container is started. In Docker, it's `entrypoint` and `command`.
They are each other's equivalent in that order, meaning specifying a `command` in Kubernetes completely overrides the `entrypoint`. When passing only flags, `args` is meant to be used.