### PR TITLE
fix: make Mongo and Redis services headless

### DIFF
--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -35,6 +35,7 @@ Array [
       "namespace": "example-mongo-app-test",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 27107,

--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -107,7 +107,7 @@ Array [
               },
               "volumeMounts": Array [
                 Object {
-                  "mountPath": "/mongo-data",
+                  "mountPath": "/data/db",
                   "name": "data",
                 },
               ],

--- a/examples/redis/__snapshots__/chart.test.ts.snap
+++ b/examples/redis/__snapshots__/chart.test.ts.snap
@@ -35,6 +35,7 @@ Array [
       "namespace": "example-redis-app-test",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 6379,

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -5,6 +5,7 @@ import { MongoProps } from "./mongo-props";
 
 export class Mongo extends Construct {
   readonly service: KubeService;
+  readonly statefulSet: KubeStatefulSet;
 
   constructor(scope: Construct, id: string, props: MongoProps) {
     super(scope, id);
@@ -35,6 +36,7 @@ export class Mongo extends Construct {
         labels: instanceLabels,
       },
       spec: {
+        clusterIp: "None",
         ports: [
           {
             port: 27107,
@@ -45,7 +47,7 @@ export class Mongo extends Construct {
       },
     });
 
-    new KubeStatefulSet(this, `${id}-sts`, {
+    this.statefulSet = new KubeStatefulSet(this, `${id}-sts`, {
       metadata: {
         labels: instanceLabels,
       },

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -86,7 +86,7 @@ export class Mongo extends Construct {
                 },
                 volumeMounts: [
                   {
-                    mountPath: "/mongo-data",
+                    mountPath: "/data/db",
                     name: "data",
                   },
                 ],

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -97,4 +97,17 @@ export class Mongo extends Construct {
       },
     });
   }
+
+  /**
+   * Get the DNS name of the instance.
+   * Each pod in a StatefulSet backed by a headless Service will have a stable
+   * DNS name. The template follows this format: <pod-name>.<service-name>.
+   * Since Pod replicas in StatefulSets are numbered, we can use the index
+   * of the Pod to get the DNS name.
+   *
+   * @param replica Number of the Pod replica to get address for
+   */
+  public getDnsName(replica = 0): string {
+    return `${this.statefulSet.name}-${replica}.${this.service.name}`;
+  }
 }

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -102,4 +102,17 @@ export class Redis extends Construct {
       },
     });
   }
+
+  /**
+   * Get the DNS name of the instance.
+   * Each pod in a StatefulSet backed by a headless Service will have a stable
+   * DNS name. The template follows this format: <pod-name>.<service-name>.
+   * Since Pod replicas in StatefulSets are numbered, we can use the index
+   * of the Pod to get the DNS name.
+   *
+   * @param replica Number of the Pod replica to get address for
+   */
+  public getDnsName(replica = 0): string {
+    return `${this.statefulSet.name}-${replica}.${this.service.name}`;
+  }
 }

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -5,6 +5,7 @@ import { RedisProps } from "./redis-props";
 
 export class Redis extends Construct {
   readonly service: KubeService;
+  readonly statefulSet: KubeStatefulSet;
 
   constructor(scope: Construct, id: string, props: RedisProps) {
     super(scope, id);
@@ -34,6 +35,7 @@ export class Redis extends Construct {
         labels: instanceLabels,
       },
       spec: {
+        clusterIp: "None",
         ports: [
           {
             port: 6379,
@@ -44,7 +46,7 @@ export class Redis extends Construct {
       },
     });
 
-    new KubeStatefulSet(this, `${id}-sts`, {
+    this.statefulSet = new KubeStatefulSet(this, `${id}-sts`, {
       metadata: {
         labels: instanceLabels,
       },

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -18,6 +18,7 @@ Array [
       "namespace": "test",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 27107,
@@ -120,6 +121,7 @@ Array [
       "name": "test-mongo-test-c844268f",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 27107,

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -88,7 +88,7 @@ Array [
               },
               "volumeMounts": Array [
                 Object {
-                  "mountPath": "/mongo-data",
+                  "mountPath": "/data/db",
                   "name": "data",
                 },
               ],
@@ -184,7 +184,7 @@ Array [
               },
               "volumeMounts": Array [
                 Object {
-                  "mountPath": "/mongo-data",
+                  "mountPath": "/data/db",
                   "name": "data",
                 },
               ],

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -115,4 +115,25 @@ describe("Mongo", () => {
       ]);
     });
   });
+
+  describe("getDnsName", () => {
+    test("Builds a DNS name for the first Pod", () => {
+      const chart = makeChart();
+      const mongo = new Mongo(chart, "mongo-test", requiredProps);
+      expect(mongo.getDnsName()).toBe("mongo-test-sts-0.mongo-test");
+    });
+
+    const tests: [number, string][] = [
+      [0, "mongo-test-sts-0.mongo-test"],
+      [1, "mongo-test-sts-1.mongo-test"],
+      [3, "mongo-test-sts-3.mongo-test"],
+    ];
+    tests.forEach(([replica, expected]) => {
+      test("Builds a string from non-empty parts", () => {
+        const chart = makeChart();
+        const mongo = new Mongo(chart, "mongo-test", requiredProps);
+        expect(mongo.getDnsName(replica)).toBe(expected);
+      });
+    });
+  });
 });

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -1,5 +1,5 @@
 import { Chart, Testing } from "cdk8s";
-import { KubeService } from "../../imports/k8s";
+import { KubeService, KubeStatefulSet } from "../../imports/k8s";
 import { Mongo, MongoProps } from "../../lib";
 import { makeChart } from "../test-util";
 
@@ -48,13 +48,21 @@ describe("Mongo", () => {
     });
   });
 
-  describe("Service instance", () => {
+  describe("Object instances", () => {
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const mongo = new Mongo(chart, "mongo-test", requiredProps);
       expect(mongo.service).toBeDefined();
       expect(mongo.service).toBeInstanceOf(KubeService);
       expect(mongo.service.name).toEqual("mongo-test");
+    });
+
+    test("Exposes statefulSet object through property", () => {
+      const chart = makeChart();
+      const mongo = new Mongo(chart, "mongo-test", requiredProps);
+      expect(mongo.statefulSet).toBeDefined();
+      expect(mongo.statefulSet).toBeInstanceOf(KubeStatefulSet);
+      expect(mongo.statefulSet.name).toEqual("mongo-test-sts");
     });
   });
 

--- a/test/redis/__snapshots__/redis.test.ts.snap
+++ b/test/redis/__snapshots__/redis.test.ts.snap
@@ -18,6 +18,7 @@ Array [
       "namespace": "test",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 6379,
@@ -126,6 +127,7 @@ Array [
       "name": "test-redis-test-c8b56c58",
     },
     "spec": Object {
+      "clusterIP": "None",
       "ports": Array [
         Object {
           "port": 6379,

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -1,5 +1,5 @@
 import { Chart, Testing } from "cdk8s";
-import { KubeService } from "../../imports/k8s";
+import { KubeService, KubeStatefulSet } from "../../imports/k8s";
 import { Redis, RedisProps } from "../../lib";
 import { makeChart } from "../test-util";
 
@@ -48,13 +48,21 @@ describe("Redis", () => {
     });
   });
 
-  describe("Service instance", () => {
+  describe("Object instances", () => {
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const redis = new Redis(chart, "redis-test", requiredProps);
       expect(redis.service).toBeDefined();
       expect(redis.service).toBeInstanceOf(KubeService);
       expect(redis.service.name).toEqual("redis-test");
+    });
+
+    test("Exposes statefulSet object through property", () => {
+      const chart = makeChart();
+      const redis = new Redis(chart, "redis-test", requiredProps);
+      expect(redis.statefulSet).toBeDefined();
+      expect(redis.statefulSet).toBeInstanceOf(KubeStatefulSet);
+      expect(redis.statefulSet.name).toEqual("redis-test-sts");
     });
   });
 

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -88,4 +88,25 @@ describe("Redis", () => {
       );
     });
   });
+
+  describe("getDnsName", () => {
+    test("Builds a DNS name for the first Pod", () => {
+      const chart = makeChart();
+      const redis = new Redis(chart, "redis-test", requiredProps);
+      expect(redis.getDnsName()).toBe("redis-test-sts-0.redis-test");
+    });
+
+    const tests: [number, string][] = [
+      [0, "redis-test-sts-0.redis-test"],
+      [1, "redis-test-sts-1.redis-test"],
+      [3, "redis-test-sts-3.redis-test"],
+    ];
+    tests.forEach(([replica, expected]) => {
+      test("Builds a string from non-empty parts", () => {
+        const chart = makeChart();
+        const redis = new Redis(chart, "redis-test", requiredProps);
+        expect(redis.getDnsName(replica)).toBe(expected);
+      });
+    });
+  });
 });


### PR DESCRIPTION
- feat: add getDnsName helper for Mongo and Redis
- fix: mount Mongo volume under correct path
- fix: make Mongo and Redis services headless
