### PR TITLE
test: verify all props are handled

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ lib/**/*.d.ts
 lib/**/*.js
 test/**/*.d.ts
 test/**/*.js
+!test/jest.setup.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   transform: {
     "^.+\\.ts$": "ts-jest",
   },
+  setupFilesAfterEnv: ["./test/jest.setup.js"],
   collectCoverageFrom: ["**/*.ts", "!**/node_modules/**", "!**/imports/**"],
   coverageReporters: ["clover", "json", "lcov", "text", "html-spa"],
 };

--- a/lib/job/job-props.ts
+++ b/lib/job/job-props.ts
@@ -6,7 +6,7 @@ export interface JobProps
   /**
    * Custom selector labels, they will be merged with the default app, role, and instance.
    * They will be applied to the workload, the pod and the service.
-   * @default { app: "<app label from chart>", role: "cronjob", instance: "<construct id>" }
+   * @default { app: "<app label from chart>", role: "job", instance: "<construct id>" }
    */
   readonly selectorLabels?: { [key: string]: string };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,10 @@
         "ts-node": "^10.5.0",
         "typescript": "^4.5.5"
       },
+      "engines": {
+        "node": ">=16.13.2",
+        "npm": ">=8.1.2"
+      },
       "peerDependencies": {
         "cdk8s": "^2.2.18",
         "constructs": "^10.0.64"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "engines": {
+    "npm": ">=8.1.2",
+    "node": ">=16.13.2"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/test/background-worker/__snapshots__/background-worker.test.ts.snap
+++ b/test/background-worker/__snapshots__/background-worker.test.ts.snap
@@ -157,7 +157,7 @@ Array [
                 "successThreshold": 1,
                 "timeoutSeconds": 2,
               },
-              "name": "my-app",
+              "name": "worker",
               "resources": Object {
                 "limits": Object {
                   "cpu": 1,

--- a/test/background-worker/background-worker.test.ts
+++ b/test/background-worker/background-worker.test.ts
@@ -43,9 +43,12 @@ describe("BackgroundWorker", () => {
         app: "my-app",
         instance: "test",
       };
-      new BackgroundWorker(chart, "worker-test", {
+      const allProps: Required<
+        Omit<BackgroundWorkerProps, "stopSignal" | "makeAffinity">
+      > = {
         ...requiredProps,
         selectorLabels,
+        containerName: "worker",
         workingDir: "/some/path",
         command: ["/bin/sh", "-c", "echo hello"],
         args: ["--foo", "bar"],
@@ -133,9 +136,17 @@ describe("BackgroundWorker", () => {
             command: ["/bin/sh", "-c", "echo hello"],
           },
         ],
-      });
+      };
+      new BackgroundWorker(chart, "worker-test", allProps);
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+
+      const deployment = results.find((obj) => obj.kind === "Deployment");
+      expect(deployment).toHaveAllProperties(allProps, [
+        "containerName",
+        "release",
+        "selectorLabels",
+      ]);
     });
 
     test("Allows specifying no affinity", () => {

--- a/test/cron-job/__snapshots__/cron-job.test.ts.snap
+++ b/test/cron-job/__snapshots__/cron-job.test.ts.snap
@@ -20,7 +20,7 @@ Array [
     "spec": Object {
       "jobTemplate": Object {
         "spec": Object {
-          "backoffLimit": 2,
+          "backoffLimit": 1,
           "template": Object {
             "spec": Object {
               "containers": Array [
@@ -69,7 +69,7 @@ Array [
                       },
                     },
                   },
-                  "name": "my-app",
+                  "name": "my-container",
                   "resources": Object {
                     "limits": Object {
                       "cpu": 1,
@@ -85,6 +85,12 @@ Array [
                     "runAsNonRoot": true,
                     "runAsUser": 1000,
                   },
+                  "volumeMounts": Array [
+                    Object {
+                      "mountPath": "/tmp",
+                      "name": "tmp-dir",
+                    },
+                  ],
                   "workingDir": "/some/path",
                 },
               ],
@@ -105,6 +111,12 @@ Array [
                 },
               ],
               "restartPolicy": "OnFailure",
+              "volumes": Array [
+                Object {
+                  "emptyDir": Object {},
+                  "name": "tmp-dir",
+                },
+              ],
             },
           },
         },

--- a/test/jest.d.ts
+++ b/test/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+  interface Matchers<R> {
+    toHaveAllProperties(props: any, omit: string[] = []): CustomMatcherResult;
+  }
+}

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,0 +1,37 @@
+expect.extend({
+  toHaveAllProperties(received, props, omit = []) {
+    let pass = true;
+    const missing = [];
+
+    const receivedStr = JSON.stringify(received);
+    for (const key of Object.keys(props)) {
+      if (omit.includes(key)) {
+        continue;
+      }
+
+      if (!receivedStr.includes(`"${key}":`)) {
+        pass = false;
+        missing.push(key);
+      }
+    }
+
+    const objectStr =
+      typeof received?.kind === "string" ? received.kind : "Object";
+    const propertyStr =
+      missing.length > 1
+        ? `properties '${missing.join("', '")}'`
+        : `property '${missing[0]}'`;
+
+    if (pass) {
+      return {
+        message: () => `expected ${objectStr} not to have ${propertyStr}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () => `expected ${objectStr} to have ${propertyStr}`,
+        pass: false,
+      };
+    }
+  },
+});

--- a/test/job/__snapshots__/job.test.ts.snap
+++ b/test/job/__snapshots__/job.test.ts.snap
@@ -18,7 +18,7 @@ Array [
       "namespace": "test",
     },
     "spec": Object {
-      "backoffLimit": 0,
+      "backoffLimit": 1,
       "template": Object {
         "spec": Object {
           "containers": Array [
@@ -67,7 +67,7 @@ Array [
                   },
                 },
               },
-              "name": "my-app",
+              "name": "my-container",
               "resources": Object {
                 "limits": Object {
                   "cpu": 1,
@@ -83,6 +83,12 @@ Array [
                 "runAsNonRoot": true,
                 "runAsUser": 1000,
               },
+              "volumeMounts": Array [
+                Object {
+                  "mountPath": "/tmp",
+                  "name": "tmp-dir",
+                },
+              ],
               "workingDir": "/some/path",
             },
           ],
@@ -103,8 +109,15 @@ Array [
             },
           ],
           "restartPolicy": "Never",
+          "volumes": Array [
+            Object {
+              "emptyDir": Object {},
+              "name": "tmp-dir",
+            },
+          ],
         },
       },
+      "ttlSecondsAfterFinished": 30,
     },
   },
 ]

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -71,7 +71,7 @@ Array [
               "args": Array [
                 "--smallfiles",
                 "--storageEngine",
-                "mmapv1",
+                "wiredTiger",
               ],
               "image": "mongo:v1",
               "name": "mongo",

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -39,12 +39,21 @@ describe("Mongo", () => {
         instance: "test",
       };
 
-      new Mongo(chart, "mongo-test", {
+      const allProps: Required<MongoProps> = {
         ...requiredProps,
         selectorLabels,
-      });
+        storageEngine: "wiredTiger",
+      };
+      new Mongo(chart, "mongo-test", allProps);
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+
+      const statefulSet = results.find((obj) => obj.kind === "StatefulSet");
+      expect(statefulSet).toHaveAllProperties(allProps, [
+        "release",
+        "selectorLabels",
+        "storageEngine",
+      ]);
     });
   });
 

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -39,12 +39,19 @@ describe("Redis", () => {
         instance: "test",
       };
 
-      new Redis(chart, "redis-test", {
+      const allProps: Required<RedisProps> = {
         ...requiredProps,
         selectorLabels,
-      });
+      };
+      new Redis(chart, "redis-test", allProps);
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();
+
+      const statefulSet = results.find((obj) => obj.kind === "StatefulSet");
+      expect(statefulSet).toHaveAllProperties(allProps, [
+        "release",
+        "selectorLabels",
+      ]);
     });
   });
 

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -271,7 +271,7 @@ Array [
                 "successThreshold": 1,
                 "timeoutSeconds": 2,
               },
-              "name": "my-app",
+              "name": "my-container",
               "ports": Array [
                 Object {
                   "containerPort": 3000,
@@ -645,7 +645,7 @@ Array [
                 "successThreshold": 1,
                 "timeoutSeconds": 2,
               },
-              "name": "my-app",
+              "name": "my-container",
               "ports": Array [
                 Object {
                   "containerPort": 3000,


### PR DESCRIPTION
We had to fix our constructs a few times now because some properties weren't being handled by the constructs, even though they were available in the interface. This PR addresses that:

- In the "All the props" tests we now use `Required<T>` which will ensure that we are actually setting all available props. Use `Omit<T, "prop">` where some properties an exclusive with others, and make sure we have tests to cover them.
- A custom Jest matcher, `toHaveAllProperties`, is a dummy way to check that all keys from the props object are present in the resulting, synthesized object. Because not all construct props are Kubernetes props, we allow to omit some key names - these keys are the prime candidates to have their own, more detailed tests.