### PR TITLE
feat: cron job schedule validation

### DIFF
--- a/examples/cron-job/README.md
+++ b/examples/cron-job/README.md
@@ -2,6 +2,20 @@
 
 Demonstrates a Cron-Job.
 
+## Cron Parser Syntax
+
+```
+*    *    *    *    *    *
+┬    ┬    ┬    ┬    ┬    ┬
+│    │    │    │    │    |
+│    │    │    │    │    └ day of week (0 - 7, 1L - 7L) (0 or 7 is Sun)
+│    │    │    │    └───── month (1 - 12)
+│    │    │    └────────── day of month (1 - 31, L)
+│    │    └─────────────── hour (0 - 23)
+│    └──────────────────── minute (0 - 59)
+└───────────────────────── second (0 - 59, optional)
+```
+
 ## Usage
 
 In order to synthesize the example to Kubernetes YAML, you need to run the following command:

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -2,6 +2,7 @@ import { Chart } from "cdk8s";
 import { Construct } from "constructs";
 import { KubeCronJob } from "../../imports/k8s";
 import { CronJobProps } from "./cron-job-props";
+import { parseExpression } from "cron-parser";
 
 export class CronJob extends Construct {
   constructor(scope: Construct, id: string, props: CronJobProps) {
@@ -65,5 +66,13 @@ export class CronJob extends Construct {
     if (!props.schedule) {
       throw new Error("Schedule must be specified");
     }
+
+    // Validate that we get a full 5 or 6 character cron expression
+    // parseExpression only checks for max length not min length
+    if (props.schedule.split(" ").length < 5) {
+      throw new Error("Invalid cron expression");
+    }
+
+    parseExpression(props.schedule);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cdk8s": "^2.2.18",
         "cdk8s-cli": "^1.0.100",
         "constructs": "^10.0.64",
+        "cron-parser": "4.3.0",
         "eslint": "^8.9.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jest": "^26.1.1",
@@ -3431,6 +3432,18 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron-parser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.3.0.tgz",
+      "integrity": "sha512-mK6qJ6k9Kn0/U7Cv6LKQnReUW3GqAW4exgwmHJGb3tPgcy0LrS+PeqxPPiwL8uW/4IJsMsCZrCc4vf1nnXMjzA==",
+      "dev": true,
+      "dependencies": {
+        "luxon": "^1.28.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7327,6 +7340,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/make-dir": {
@@ -15482,6 +15504,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cron-parser": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.3.0.tgz",
+      "integrity": "sha512-mK6qJ6k9Kn0/U7Cv6LKQnReUW3GqAW4exgwmHJGb3tPgcy0LrS+PeqxPPiwL8uW/4IJsMsCZrCc4vf1nnXMjzA==",
+      "dev": true,
+      "requires": {
+        "luxon": "^1.28.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -18439,6 +18470,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "dev": true
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cdk8s": "^2.2.18",
     "cdk8s-cli": "^1.0.100",
     "constructs": "^10.0.64",
+    "cron-parser": "4.3.0",
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^26.1.1",

--- a/test/cron-job/cron-job.test.ts
+++ b/test/cron-job/cron-job.test.ts
@@ -116,6 +116,42 @@ describe("CronJob", () => {
       const cron = results.find((obj) => obj.kind === "CronJob");
       expect(cron).toHaveProperty("spec.jobTemplate.spec.backoffLimit", 42);
     });
+
+    describe("Schedule Validation", () => {
+      test.each([
+        ["Schedule must be specified", "", "Empty schedule"],
+        [
+          "Invalid cron expression",
+          "* * * *",
+          "Too short cron schedule string",
+        ],
+        [
+          "Invalid cron expression",
+          "* * * * * * *",
+          "Too long cron schedule string",
+        ],
+        [
+          "Constraint error, got value 100 expected range 0-59",
+          "100 * * * * *",
+          "Invalid second",
+        ],
+        [
+          "Constraint error, got value 100 expected range 0-59",
+          "* 100 * * * *",
+          "Invalid minute",
+        ],
+      ])(
+        "Throws '%s' error with cron schedule (%s) - %s",
+        (errorMessage, schedule) => {
+          expect(() => {
+            synthCronJob({
+              ...requiredProps,
+              schedule: schedule,
+            });
+          }).toThrowError(errorMessage);
+        }
+      );
+    });
   });
 
   describe("Container name", () => {


### PR DESCRIPTION
- talis/platform#5474

Adds validation of the passed in schedule for the cron job against 5 or 6 long cron syntax using cron-parser.