### PR TITLE
fix: change TTL to be timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 - `getCanaryStage` - Gets the stage of a canary deployment from an environment variable, and validates its value.
 - `getDockerTag` - Gets the Docker tag from an environment variable, and validates its value.
 - `getWatermark` - Gets the watermark from an environment variable.
-- `getTtl` - Gets the TTL datetime from an environment variable.
+- `getTtlTimestamp` - Gets the TTL timestamp from an environment variable.
 - `getEksDashboardUrl` - Builds the URL of the Kubernetes dashboard for a given cluster and namespace.
 - `getGraphsUrl` - Builds the URL of the Grafana workload dashboard for a given cluster and namespace.
 - `getLogsUrl` - Builds the URL of the Grafana logs dashboard for a given cluster and app.

--- a/lib/common/env-util.ts
+++ b/lib/common/env-util.ts
@@ -8,14 +8,20 @@ export function getWatermark({
   return process.env[envVarName] || defaultValue;
 }
 
-export function getTtl({ envVarName = "TTL" } = {}): string | undefined {
+export function getTtlTimestamp({ envVarName = "TTL" } = {}):
+  | number
+  | undefined {
   const ttl = process.env[envVarName];
 
-  if (ttl && !/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d/.test(ttl)) {
+  if (!ttl) {
+    return undefined;
+  }
+
+  if (!/^\d{10,}$/.test(ttl)) {
     throw new Error(`Invalid TTL: ${ttl}`);
   }
 
-  return ttl;
+  return Number(ttl);
 }
 
 export function getDockerTag(

--- a/lib/talis-chart/talis-chart.ts
+++ b/lib/talis-chart/talis-chart.ts
@@ -14,8 +14,8 @@ export interface TalisChartProps extends ChartProps {
   readonly region: TalisShortRegion;
   /** An identifier, will be appended to the namespace */
   readonly watermark: string;
-  /** Time and date after which the namespace will be deleted, in ISO 8601 format */
-  readonly ttl?: string;
+  /** Timestamp after which the namespace will be deleted */
+  readonly ttl?: number;
 }
 
 /** @private */
@@ -50,7 +50,7 @@ export class TalisChart extends Chart {
     };
 
     if (ttl) {
-      labels["ttl"] = ttl;
+      labels["ttl"] = ttl.toString();
     }
 
     super(scope, id, {

--- a/test/common/__snapshots__/env-util.test.ts.snap
+++ b/test/common/__snapshots__/env-util.test.ts.snap
@@ -10,20 +10,12 @@ exports[`env-util getDockerTag Throws if env var is empty 1`] = `"Docker tag var
 
 exports[`env-util getDockerTag Throws if tag is not valid for the environment 1`] = `"\\"stable\\" is not a valid Docker tag for production, please set APP_DOCKER_TAG to a valid tag"`;
 
-exports[`env-util getTtl Throws on invalid TTL 2021 1`] = `"Invalid TTL: 2021"`;
+exports[`env-util getTtlTimestamp Throws on invalid TTL 123456789 1`] = `"Invalid TTL: 123456789"`;
 
-exports[`env-util getTtl Throws on invalid TTL 2021-02 1`] = `"Invalid TTL: 2021-02"`;
+exports[`env-util getTtlTimestamp Throws on invalid TTL 123456789a 1`] = `"Invalid TTL: 123456789a"`;
 
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03 1`] = `"Invalid TTL: 2021-02-03"`;
+exports[`env-util getTtlTimestamp Throws on invalid TTL 1234567890.12 1`] = `"Invalid TTL: 1234567890.12"`;
 
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03T 1`] = `"Invalid TTL: 2021-02-03T"`;
+exports[`env-util getTtlTimestamp Throws on invalid TTL a123456789 1`] = `"Invalid TTL: a123456789"`;
 
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03T04: 1`] = `"Invalid TTL: 2021-02-03T04:"`;
-
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03T04:05 1`] = `"Invalid TTL: 2021-02-03T04:05"`;
-
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03T04:05: 1`] = `"Invalid TTL: 2021-02-03T04:05:"`;
-
-exports[`env-util getTtl Throws on invalid TTL 2021-02-03T04:05:0 1`] = `"Invalid TTL: 2021-02-03T04:05:0"`;
-
-exports[`env-util getTtl Throws on invalid TTL foobar 1`] = `"Invalid TTL: foobar"`;
+exports[`env-util getTtlTimestamp Throws on invalid TTL foobar 1`] = `"Invalid TTL: foobar"`;

--- a/test/common/env-util.test.ts
+++ b/test/common/env-util.test.ts
@@ -2,7 +2,7 @@ import {
   getCanaryStage,
   getDockerTag,
   getWatermark,
-  getTtl,
+  getTtlTimestamp,
   TalisDeploymentEnvironment,
 } from "../../lib";
 
@@ -50,41 +50,35 @@ describe("env-util", () => {
     });
   });
 
-  describe("getTtl", () => {
+  describe("getTtlTimestamp", () => {
     test("Gets TTL", () => {
-      process.env.TTL = "2021-02-03T04:05:06Z";
-      expect(getTtl()).toBe("2021-02-03T04:05:06Z");
+      process.env.TTL = "1650172800";
+      expect(getTtlTimestamp()).toBe(1650172800);
     });
 
     test("Returns undefined if no TTL is set", () => {
-      expect(getTtl()).toBeUndefined();
+      expect(getTtlTimestamp()).toBeUndefined();
     });
 
     test("Gets TTL from custom env var", () => {
-      process.env.EXPIRY_DATE = "2021-02-03T04:05:06+07:00";
-      expect(getTtl({ envVarName: "EXPIRY_DATE" })).toBe(
-        "2021-02-03T04:05:06+07:00"
-      );
+      process.env.EXPIRY_DATE = "2147483647";
+      expect(getTtlTimestamp({ envVarName: "EXPIRY_DATE" })).toBe(2147483647);
     });
 
     test("Returns undefined if no custom env var is set", () => {
-      expect(getTtl({ envVarName: "EXPIRY_DATE" })).toBeUndefined();
+      expect(getTtlTimestamp({ envVarName: "EXPIRY_DATE" })).toBeUndefined();
     });
 
     [
-      "2021-02-03T04:05:0",
-      "2021-02-03T04:05:",
-      "2021-02-03T04:05",
-      "2021-02-03T04:",
-      "2021-02-03T",
-      "2021-02-03",
-      "2021-02",
-      "2021",
+      "1234567890.12",
+      "a123456789",
+      "123456789a",
+      "123456789",
       "foobar",
     ].forEach((ttl) => {
       test(`Throws on invalid TTL ${ttl}`, () => {
         process.env.TTL = ttl;
-        expect(() => getTtl()).toThrowErrorMatchingSnapshot();
+        expect(() => getTtlTimestamp()).toThrowErrorMatchingSnapshot();
       });
     });
   });

--- a/test/talis-chart/talis-chart.test.ts
+++ b/test/talis-chart/talis-chart.test.ts
@@ -213,7 +213,7 @@ describe("TalisChart", () => {
       environment: TalisDeploymentEnvironment.ONDEMAND,
       region: TalisShortRegion.EU,
       watermark: "test",
-      ttl: "2021-02-03T04:05:06Z",
+      ttl: 1234567890,
     });
 
     new ApiObject(chart, "foo", {
@@ -223,13 +223,7 @@ describe("TalisChart", () => {
 
     const results = Testing.synth(chart);
     expect(results).toHaveLength(2);
-    expect(results[0].metadata.labels).toHaveProperty(
-      "ttl",
-      "2021-02-03T04:05:06Z"
-    );
-    expect(results[1].metadata.labels).toHaveProperty(
-      "ttl",
-      "2021-02-03T04:05:06Z"
-    );
+    expect(results[0].metadata.labels).toHaveProperty("ttl", "1234567890");
+    expect(results[1].metadata.labels).toHaveProperty("ttl", "1234567890");
   });
 });


### PR DESCRIPTION
* Kubernetes labels must not contain `:`, only alphanumerics, `-`, `_`, and `.`, hence we need to change TTL to be a timestamp.
* Replace `getTtl` with `getTtlTimestamp`.