### PR TITLE
feat: mongo persistent storage and resource limits

### DIFF
--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -108,19 +108,28 @@ Array [
               "volumeMounts": Array [
                 Object {
                   "mountPath": "/data/db",
-                  "name": "data",
+                  "name": "mongo-data",
                 },
               ],
             },
           ],
-          "volumes": Array [
-            Object {
-              "emptyDir": Object {},
-              "name": "data",
-            },
-          ],
         },
       },
+      "volumeClaimTemplates": Array [
+        Object {
+          "metadata": Object {
+            "name": "mongo-data",
+          },
+          "spec": Object {
+            "resources": Object {
+              "requests": Object {
+                "storage": "20Gi",
+              },
+            },
+            "storageClassName": "general-purpose-delete",
+          },
+        },
+      ],
     },
   },
 ]

--- a/lib/mongo/mongo-props.ts
+++ b/lib/mongo/mongo-props.ts
@@ -1,3 +1,5 @@
+import { Quantity, ResourceRequirements } from "../../imports/k8s";
+
 export interface MongoProps {
   /**
    * Custom selector labels, they will be merged with the default app, role, and instance.
@@ -14,4 +16,16 @@ export interface MongoProps {
    * @default mmapv1
    */
   readonly storageEngine?: "wiredTiger" | "inMemory" | "mmapv1";
+
+  /**
+   * Storage for the mongo pod
+   * @default Quantity.fromString("20Gi")
+   */
+  readonly storageSize?: Quantity;
+
+  /**
+   * Resources for the mongo Pod
+   * @default { limits: { cpu: "100m", memory: "500Mi" } }
+   */
+  readonly resources?: ResourceRequirements;
 }

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -89,19 +89,28 @@ Array [
               "volumeMounts": Array [
                 Object {
                   "mountPath": "/data/db",
-                  "name": "data",
+                  "name": "mongo-data",
                 },
               ],
             },
           ],
-          "volumes": Array [
-            Object {
-              "emptyDir": Object {},
-              "name": "data",
-            },
-          ],
         },
       },
+      "volumeClaimTemplates": Array [
+        Object {
+          "metadata": Object {
+            "name": "mongo-data",
+          },
+          "spec": Object {
+            "resources": Object {
+              "requests": Object {
+                "storage": "20Gi",
+              },
+            },
+            "storageClassName": "general-purpose-delete",
+          },
+        },
+      ],
     },
   },
 ]
@@ -185,19 +194,28 @@ Array [
               "volumeMounts": Array [
                 Object {
                   "mountPath": "/data/db",
-                  "name": "data",
+                  "name": "mongo-data",
                 },
               ],
             },
           ],
-          "volumes": Array [
-            Object {
-              "emptyDir": Object {},
-              "name": "data",
-            },
-          ],
         },
       },
+      "volumeClaimTemplates": Array [
+        Object {
+          "metadata": Object {
+            "name": "mongo-data",
+          },
+          "spec": Object {
+            "resources": Object {
+              "requests": Object {
+                "storage": "20Gi",
+              },
+            },
+            "storageClassName": "general-purpose-delete",
+          },
+        },
+      ],
     },
   },
 ]

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -1,5 +1,5 @@
 import { Chart, Testing } from "cdk8s";
-import { KubeService, KubeStatefulSet } from "../../imports/k8s";
+import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
 import { Mongo, MongoProps } from "../../lib";
 import { makeChart } from "../test-util";
 
@@ -43,6 +43,13 @@ describe("Mongo", () => {
         ...requiredProps,
         selectorLabels,
         storageEngine: "wiredTiger",
+        storageSize: Quantity.fromString("20Gi"),
+        resources: {
+          limits: {
+            cpu: Quantity.fromString("100m"),
+            memory: Quantity.fromString("500Mi"),
+          },
+        },
       };
       new Mongo(chart, "mongo-test", allProps);
       const results = Testing.synth(chart);
@@ -53,6 +60,8 @@ describe("Mongo", () => {
         "release",
         "selectorLabels",
         "storageEngine",
+        "storageSize",
+        "resources",
       ]);
     });
   });


### PR DESCRIPTION
- talis/platform#5550

Moves mongo to use a persistent storage volume over empty directory, this will allow the mongo pod to be restarted and data not lost i.e. seed data will stay around

Allows the end user to specify the resources for mongo pod incase these need to be higher i.e. when running a load test