### PR TITLE
feat: add startingDeadlineSeconds to cron job

### DIFF
--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -33,4 +33,9 @@ export interface CronJobProps
    * @default 6
    */
   readonly backoffLimit?: number;
+
+  /**
+   * Specifies the deadline in seconds for starting the job if it misses its scheduled time.
+   */
+  readonly startingDeadlineSeconds?: number;
 }

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -29,6 +29,7 @@ export class CronJob extends Construct {
       },
       spec: {
         schedule: props.schedule,
+        startingDeadlineSeconds: props.startingDeadlineSeconds,
         jobTemplate: {
           spec: {
             backoffLimit: props.backoffLimit ?? 6,

--- a/test/cron-job/__snapshots__/cron-job.test.ts.snap
+++ b/test/cron-job/__snapshots__/cron-job.test.ts.snap
@@ -122,6 +122,7 @@ Array [
         },
       },
       "schedule": "0 0 13 * 5",
+      "startingDeadlineSeconds": 200,
     },
   },
 ]

--- a/test/cron-job/cron-job.test.ts
+++ b/test/cron-job/cron-job.test.ts
@@ -59,6 +59,7 @@ describe("CronJob", () => {
         envFrom: [{ configMapRef: { name: "foo-config" } }],
         imagePullPolicy: "Always",
         imagePullSecrets: [{ name: "foo-secret" }],
+        startingDeadlineSeconds: 200,
         resources: {
           requests: {
             cpu: Quantity.fromNumber(0.1),


### PR DESCRIPTION
Adds [`startingDeadlineSeconds`](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#starting-deadline) to cron job configuration.