### PR TITLE
feat: add successfulJobsHistoryLimit and failedJobsHistoryLimit to cron job

### DIFF
--- a/examples/cron-job/__snapshots__/chart.test.ts.snap
+++ b/examples/cron-job/__snapshots__/chart.test.ts.snap
@@ -54,6 +54,7 @@ Array [
       "namespace": "example-cron-app-test",
     },
     "spec": Object {
+      "failedJobsHistoryLimit": 1,
       "jobTemplate": Object {
         "spec": Object {
           "backoffLimit": 6,
@@ -89,6 +90,7 @@ Array [
         },
       },
       "schedule": "0 0 13 * 5",
+      "successfulJobsHistoryLimit": 3,
     },
   },
 ]
@@ -148,6 +150,7 @@ Array [
       "namespace": "example-cron-app-test",
     },
     "spec": Object {
+      "failedJobsHistoryLimit": 1,
       "jobTemplate": Object {
         "spec": Object {
           "backoffLimit": 6,
@@ -183,6 +186,7 @@ Array [
         },
       },
       "schedule": "0 0 13 * 5",
+      "successfulJobsHistoryLimit": 3,
     },
   },
 ]

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -40,12 +40,12 @@ export interface CronJobProps
   readonly startingDeadlineSeconds?: number;
 
   /**
-   * Specifies the number of successful finished jobs to retain.
+   * Specifies the number of successful finished jobs to retain. @default 3
    */
   readonly successfulJobsHistoryLimit?: number;
 
   /**
-   * Specifies the number of failed finished jobs to retain.
+   * Specifies the number of failed finished jobs to retain. @default 1
    */
   readonly failedJobsHistoryLimit?: number;
 }

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -38,4 +38,14 @@ export interface CronJobProps
    * Specifies the deadline in seconds for starting the job if it misses its scheduled time.
    */
   readonly startingDeadlineSeconds?: number;
+
+  /**
+   * Specifies the number of successful finished jobs to retain.
+   */
+  readonly successfulJobsHistoryLimit?: number;
+
+  /**
+   * Specifies the number of failed finished jobs to retain.
+   */
+  readonly failedJobsHistoryLimit?: number;
 }

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -40,12 +40,14 @@ export interface CronJobProps
   readonly startingDeadlineSeconds?: number;
 
   /**
-   * Specifies the number of successful finished jobs to retain. @default 3
+   * Specifies the number of successful finished jobs to retain.
+   * @default 3
    */
   readonly successfulJobsHistoryLimit?: number;
 
   /**
-   * Specifies the number of failed finished jobs to retain. @default 1
+   * Specifies the number of failed finished jobs to retain.
+   * @default 1
    */
   readonly failedJobsHistoryLimit?: number;
 }

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -30,6 +30,8 @@ export class CronJob extends Construct {
       spec: {
         schedule: props.schedule,
         startingDeadlineSeconds: props.startingDeadlineSeconds,
+        successfulJobsHistoryLimit: props.successfulJobsHistoryLimit ?? 3,
+        failedJobsHistoryLimit: props.failedJobsHistoryLimit ?? 1,
         jobTemplate: {
           spec: {
             backoffLimit: props.backoffLimit ?? 6,

--- a/test/cron-job/__snapshots__/cron-job.test.ts.snap
+++ b/test/cron-job/__snapshots__/cron-job.test.ts.snap
@@ -18,6 +18,7 @@ Array [
       "namespace": "test",
     },
     "spec": Object {
+      "failedJobsHistoryLimit": 2,
       "jobTemplate": Object {
         "spec": Object {
           "backoffLimit": 1,
@@ -123,6 +124,7 @@ Array [
       },
       "schedule": "0 0 13 * 5",
       "startingDeadlineSeconds": 200,
+      "successfulJobsHistoryLimit": 4,
     },
   },
 ]
@@ -142,6 +144,7 @@ Array [
       "name": "test-cron-job-test-c88f7970",
     },
     "spec": Object {
+      "failedJobsHistoryLimit": 1,
       "jobTemplate": Object {
         "spec": Object {
           "backoffLimit": 2,
@@ -166,6 +169,7 @@ Array [
         },
       },
       "schedule": "0 0 13 * 5",
+      "successfulJobsHistoryLimit": 3,
     },
   },
 ]

--- a/test/cron-job/cron-job.test.ts
+++ b/test/cron-job/cron-job.test.ts
@@ -60,6 +60,8 @@ describe("CronJob", () => {
         imagePullPolicy: "Always",
         imagePullSecrets: [{ name: "foo-secret" }],
         startingDeadlineSeconds: 200,
+        successfulJobsHistoryLimit: 4,
+        failedJobsHistoryLimit: 2,
         resources: {
           requests: {
             cpu: Quantity.fromNumber(0.1),


### PR DESCRIPTION
Adds `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` to cron job configuration