### PR TITLE
feat: plat-5579 redact secrets if env var is set

### DIFF
--- a/lib/data/secret.ts
+++ b/lib/data/secret.ts
@@ -146,6 +146,10 @@ export class Secret extends Construct {
       value = Buffer.from(value).toString("base64");
     }
 
+    if (process.env.CDK8S_REDACT_SECRET_DATA) {
+      value = value.replace(/./g, "*");
+    }
+
     this._data[key] = value;
   }
 

--- a/test/data/secret.test.ts
+++ b/test/data/secret.test.ts
@@ -258,4 +258,24 @@ describe("Secret", () => {
       });
     });
   });
+  describe("when CDK8S_REDACT_SECRET_DATA is set to true", () => {
+    const PROCESS_ENV = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...PROCESS_ENV };
+      process.env.CDK8S_REDACT_SECRET_DATA = "true";
+    });
+
+    afterEach(() => {
+      process.env = PROCESS_ENV;
+    });
+
+    test("secrets are redacted", () => {
+      const chart = Testing.chart();
+      const secret = new Secret(chart, "test");
+      secret.setData("test", "this will be redacted");
+      expect(secret.data).toEqual({ test: "****************************" });
+    });
+  });
 });


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5579

Redact secrets in env var `CDK8S_REDACT_SECRET_DATA` is set.

This is used for snapshot testing where we want to create a snapshot that does not contain a secret.