### PR TITLE
feat: allow for WebService additional external hostnames

### DIFF
--- a/e2e/full-stack.bats
+++ b/e2e/full-stack.bats
@@ -65,4 +65,8 @@ teardown_file() {
 @test "full-stack: verify WebService external DNS" {
   run http_get "https://cdk8s-e2e-${CIRCLE_BUILD_NUM}-web-service.talis.io/env"
   assert_contains "$output" "WATERMARK=${CIRCLE_BUILD_NUM}"
+
+  # Additional external DNS
+  run http_get "https://cdk8s-e2e-${CIRCLE_BUILD_NUM}-extra.talis.io/env"
+  assert_contains "$output" "WATERMARK=${CIRCLE_BUILD_NUM}"
 }

--- a/e2e/full-stack.bats
+++ b/e2e/full-stack.bats
@@ -40,7 +40,7 @@ teardown_file() {
 }
 
 @test "full-stack: verify ResqueWeb load balancer" {
-  attempts=10 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "resque-web-ingress"
+  attempts=20 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "resque-web-ingress"
   alb_hostname="$output"
   assert_contains "$alb_hostname" "internal-"
   assert_contains "$alb_hostname" ".elb.amazonaws.com"
@@ -54,7 +54,7 @@ teardown_file() {
 }
 
 @test "full-stack: verify WebService load balancer" {
-  attempts=10 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-ingress"
+  attempts=20 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-ingress"
   alb_hostname="$output"
   assert_contains "$alb_hostname" ".elb.amazonaws.com"
 

--- a/e2e/full-stack.e2e.ts
+++ b/e2e/full-stack.e2e.ts
@@ -41,6 +41,7 @@ export class FullStackChart extends TalisChart {
     const busyboxVersion = "1.35.0";
     const busyboxImage = `docker.io/busybox:${busyboxVersion}`;
     const externalHostname = `cdk8s-e2e-${watermark}-web-service.${domain}`;
+    const additionalHostname = `cdk8s-e2e-${watermark}-extra.${domain}`;
     const resqueHostname = `cdk8s-e2e-${watermark}-resque.${domain}`;
 
     const commonResources: ResourceRequirements = {
@@ -161,6 +162,7 @@ export class FullStackChart extends TalisChart {
       replicas: 2,
       tlsDomain: `*.${domain}`,
       externalHostname: externalHostname,
+      additionalExternalHostnames: [additionalHostname],
       externalUrl: `https://${externalHostname}/`,
       repositoryUrl: "https://github.com/stefanprodan/podinfo",
       issuesUrl: "https://github.com/talis/talis-cdk8s-constructs/issues",

--- a/e2e/lib/test_helper.bash
+++ b/e2e/lib/test_helper.bash
@@ -34,7 +34,7 @@ cdk8s_synth() {
 # @param {string} URL to get
 http_get() {
   curl --silent --show-error --fail \
-    --retry 15 --retry-delay 10 --retry-max-time 150 --retry-connrefused "$1"
+    --retry 20 --retry-delay 10 --retry-max-time 150 --retry-connrefused "$1"
 }
 
 # Gets the value of a column.

--- a/e2e/web-service-canary.bats
+++ b/e2e/web-service-canary.bats
@@ -32,11 +32,11 @@ teardown_file() {
   run_kubectl apply -f dist-web-service-stage-canary/
   run_kubectl rollout status deployment web-svc-canary --watch
 
-  attempts=10 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-ingress"
+  attempts=20 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-ingress"
   alb_hostname="$output"
   assert_contains "$alb_hostname" ".elb.amazonaws.com"
 
-  attempts=10 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-canary-ingress"
+  attempts=20 delay=10 run get_property ".status.loadBalancer.ingress[0].hostname" "ingress" "web-svc-canary-ingress"
   alb_canary_hostname="$output"
   assert_contains "$alb_canary_hostname" ".elb.amazonaws.com"
 

--- a/lib/background-worker/background-worker.ts
+++ b/lib/background-worker/background-worker.ts
@@ -53,6 +53,7 @@ export class BackgroundWorker extends Construct {
             priorityClassName: props.priorityClassName,
             terminationGracePeriodSeconds: props.terminationGracePeriodSeconds,
             volumes: props.volumes,
+            hostAliases: props.hostAliases,
             initContainers: props.initContainers,
             containers: [
               {

--- a/lib/common/workload-props.ts
+++ b/lib/common/workload-props.ts
@@ -1,4 +1,9 @@
-import { Affinity, LocalObjectReference, Volume } from "../../imports/k8s";
+import {
+  Affinity,
+  HostAlias,
+  LocalObjectReference,
+  Volume,
+} from "../../imports/k8s";
 
 export function defaultAffinity(matchLabels: {
   [key: string]: string;
@@ -70,4 +75,9 @@ export interface WorkloadProps {
    * List of volumes that can be mounted by containers belonging to the Pod.
    */
   readonly volumes?: Volume[];
+
+  /**
+   * An optional list of hosts and IPs that will be injected into the pod's hosts file.
+   */
+  readonly hostAliases?: HostAlias[];
 }

--- a/lib/web-service/web-service-props.ts
+++ b/lib/web-service/web-service-props.ts
@@ -187,4 +187,9 @@ export interface WebServiceProps
    * Hostname to add External DNS record for the ingress.
    */
   readonly externalHostname?: string;
+
+  /**
+   *
+   */
+  readonly additionalExternalHostnames?: string[];
 }

--- a/lib/web-service/web-service.ts
+++ b/lib/web-service/web-service.ts
@@ -274,6 +274,7 @@ export class WebService extends Construct {
                 props.terminationGracePeriodSeconds,
               initContainers: props.initContainers,
               containers: containers,
+              hostAliases: props.hostAliases,
               volumes: volumes.length > 0 ? volumes : undefined,
             },
           },

--- a/test/background-worker/__snapshots__/background-worker.test.ts.snap
+++ b/test/background-worker/__snapshots__/background-worker.test.ts.snap
@@ -196,6 +196,15 @@ exports[`BackgroundWorker > Props > All the props 1`] = `
               "workingDir": "/some/path",
             },
           ],
+          "hostAliases": [
+            {
+              "hostnames": [
+                "foo.example.com",
+                "bar.example.com",
+              ],
+              "ip": "127.0.0.1",
+            },
+          ],
           "imagePullSecrets": [
             {
               "name": "foo-secret",

--- a/test/background-worker/background-worker.test.ts
+++ b/test/background-worker/background-worker.test.ts
@@ -131,6 +131,12 @@ describe("BackgroundWorker", () => {
           successThreshold: 1,
           timeoutSeconds: 2,
         },
+        hostAliases: [
+          {
+            ip: "127.0.0.1",
+            hostnames: ["foo.example.com", "bar.example.com"],
+          },
+        ],
         volumes: [
           {
             name: "tmp-dir",

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -395,6 +395,15 @@ exports[`WebService > Props > All the props 1`] = `
               ],
             },
           ],
+          "hostAliases": [
+            {
+              "hostnames": [
+                "foo.example.com",
+                "bar.example.com",
+              ],
+              "ip": "127.0.0.1",
+            },
+          ],
           "imagePullSecrets": [
             {
               "name": "foo-secret",
@@ -799,6 +808,15 @@ exports[`WebService > Props > All the props 1`] = `
                   "readOnly": true,
                 },
               ],
+            },
+          ],
+          "hostAliases": [
+            {
+              "hostnames": [
+                "foo.example.com",
+                "bar.example.com",
+              ],
+              "ip": "127.0.0.1",
             },
           ],
           "imagePullSecrets": [

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -543,7 +543,6 @@ exports[`WebService > Props > All the props 1`] = `
         "alb.ingress.kubernetes.io/success-codes": "200,303",
         "alb.ingress.kubernetes.io/tags": "service=my-app,instance=web,environment=test",
         "alb.ingress.kubernetes.io/target-type": "ip",
-        "external-dns.alpha.kubernetes.io/hostname": "api.example.com",
       },
       "labels": {
         "app": "my-app",
@@ -568,27 +567,6 @@ exports[`WebService > Props > All the props 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
-      "rules": [
-        {
-          "host": "api2.example.com",
-          "http": {
-            "paths": [
-              {
-                "backend": {
-                  "service": {
-                    "name": "test-web-web-canary-service-c852817c",
-                    "port": {
-                      "number": 80,
-                    },
-                  },
-                },
-                "path": "/",
-                "pathType": "Prefix",
-              },
-            ],
-          },
-        },
-      ],
       "tls": [
         {
           "hosts": [

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -154,6 +154,27 @@ exports[`WebService > Props > All the props 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "host": "api2.example.com",
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "test-web-web-service-c828a686",
+                    "port": {
+                      "number": 80,
+                    },
+                  },
+                },
+                "path": "/",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -538,6 +559,27 @@ exports[`WebService > Props > All the props 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "host": "api2.example.com",
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "test-web-web-canary-service-c852817c",
+                    "port": {
+                      "number": 80,
+                    },
+                  },
+                },
+                "path": "/",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -232,6 +232,7 @@ describe("WebService", () => {
           },
         ],
         externalHostname: "api.example.com",
+        additionalExternalHostnames: ["api2.example.com"],
       };
       new WebService(chart, "web", allProps);
       const results = Testing.synth(chart);
@@ -240,6 +241,7 @@ describe("WebService", () => {
       const deployment = results.find((obj) => obj.kind === "Deployment");
       expect(deployment).toHaveAllProperties(allProps, [
         ...Object.keys(annotations),
+        "additionalExternalHostnames",
         "canary",
         "containerName",
         "externalHostname",

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -207,6 +207,12 @@ describe("WebService", () => {
           successThreshold: 1,
           timeoutSeconds: 2,
         },
+        hostAliases: [
+          {
+            ip: "127.0.0.1",
+            hostnames: ["foo.example.com", "bar.example.com"],
+          },
+        ],
         volumes: [
           {
             name: "foo-volume",


### PR DESCRIPTION
- Allow for WebService's additional external hostnames.
- Allow to set hostAliases in WebService and BackgroundWorker.
- Always retry up to 20 times in e2e tests.
- Fix external DNS being set on the canary Ingress (with the same hostname as non-canary).