### PR TITLE
feat: add /status check to ResqueWeb

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,9 @@ imports/**/*.js
 **/nginx/*.conf
 
 # Typescript is our source-code; generated JS and d.ts is left unlinted.
+e2e/**/*.d.ts
+e2e/**/*.js
+e2e/**/construct-metadata.json
 examples/**/*.d.ts
 examples/**/*.js
 lib/**/*.d.ts

--- a/examples/background-worker/__snapshots__/chart.test.ts.snap
+++ b/examples/background-worker/__snapshots__/chart.test.ts.snap
@@ -87,6 +87,7 @@ exports[`BackgroundWorker example > Change release version 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "worker-test-resque-develop",
@@ -199,6 +200,16 @@ exports[`BackgroundWorker example > Change release version 1`] = `
               ],
               "image": "talis/resque-web:stable",
               "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "name": "worker",
               "ports": [
                 {
@@ -206,6 +217,16 @@ exports[`BackgroundWorker example > Change release version 1`] = `
                   "protocol": "TCP",
                 },
               ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -215,6 +236,15 @@ exports[`BackgroundWorker example > Change release version 1`] = `
                   "cpu": "50m",
                   "memory": "100Mi",
                 },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
               },
             },
           ],
@@ -434,6 +464,7 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "worker-test-resque-develop",
@@ -546,6 +577,16 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
               ],
               "image": "talis/resque-web:stable",
               "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "name": "worker",
               "ports": [
                 {
@@ -553,6 +594,16 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
                   "protocol": "TCP",
                 },
               ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -562,6 +613,15 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
                   "cpu": "50m",
                   "memory": "100Mi",
                 },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
               },
             },
           ],

--- a/lib/web-service/resque-web.ts
+++ b/lib/web-service/resque-web.ts
@@ -38,15 +38,6 @@ export class ResqueWeb extends Construct {
       eksDashboardUrl: "None",
       uptimeUrl: "None",
 
-      // Ingress options
-      internal: true,
-      canary: false,
-      selectorLabels: {
-        app: "resque",
-        ...props.selectorLabels,
-      },
-      ingressAnnotations: ingressAnnotations,
-
       // Container options
       image: `talis/resque-web:${release}`,
       release: release,
@@ -92,8 +83,20 @@ export class ResqueWeb extends Construct {
         successThreshold: 1,
       },
 
+      // Ingress options
+      internal: true,
+      canary: false,
+
       // Overrides
       ...props,
+      selectorLabels: {
+        app: "resque",
+        ...props.selectorLabels,
+      },
+      ingressAnnotations: {
+        ...ingressAnnotations,
+        ...props.ingressAnnotations,
+      },
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,14 @@
         "@commitlint/config-conventional": "^17.1.0",
         "@types/lodash": "^4.14.186",
         "@types/mock-fs": "^4.13.1",
-        "@types/node": "^18.11.0",
-        "@typescript-eslint/eslint-plugin": "^5.40.0",
-        "@typescript-eslint/parser": "^5.40.0",
-        "bats": "^1.8.0",
+        "@types/node": "^18.11.3",
+        "@typescript-eslint/eslint-plugin": "^5.40.1",
+        "@typescript-eslint/parser": "^5.40.1",
+        "bats": "^1.8.2",
         "c8": "^7.12.0",
-        "cdk8s": "^2.5.19",
-        "cdk8s-cli": "^2.1.17",
-        "constructs": "^10.1.131",
+        "cdk8s": "^2.5.23",
+        "cdk8s-cli": "^2.1.22",
+        "constructs": "^10.1.135",
         "eslint": "^8.25.0",
         "eslint-config-prettier": "^8.5.0",
         "husky": "^8.0.1",
@@ -42,8 +42,8 @@
         "npm": ">=8.1.2"
       },
       "peerDependencies": {
-        "cdk8s": "^2.5.19",
-        "constructs": "^10.1.131"
+        "cdk8s": "^2.5.23",
+        "constructs": "^10.1.135"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -571,22 +571,37 @@
       }
     },
     "node_modules/@jsii/check-node": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.69.0.tgz",
-      "integrity": "sha512-a+g42wsMM1SB91f+/ZGqtEccaCfJkpfbKYczzLM8tN7P00TGHraTFBqd/G6jndRw4mrR+T+3GaAKlzmNLqYIUg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.70.0.tgz",
+      "integrity": "sha512-lebc8VgekEEStNn1K/khkRzs41sjC88tBE0xEkjDpsFNBMXNuek8I9dkaFbjQ9c+P0TsOa17JJUMLxjgCtjW5A==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
       },
       "engines": {
         "node": ">= 14.6.0"
       }
     },
+    "node_modules/@jsii/check-node/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@jsii/spec": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.69.0.tgz",
-      "integrity": "sha512-Dj41jQc6GgbXHyc/IzhmKdrMJSuF7hetRmCkwMvj0/T2WWNAUK/UNNw40QnksfIhB8yooDAoMqGVU/71fbDyaA==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.70.0.tgz",
+      "integrity": "sha512-2l09VaZvT8OLRMwtVm+JxzrzpO6+eR4Scn9B8+zvE9NptX5jN+X68V0VngDuWTJqHs7ntbYCmHQDWuLm0bPr1A==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.11.0"
@@ -975,9 +990,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
-      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
+      "version": "18.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
+      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -998,15 +1013,21 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
-      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
+      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/type-utils": "5.40.0",
-        "@typescript-eslint/utils": "5.40.0",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/type-utils": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -1031,14 +1052,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
-      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
+      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1058,13 +1079,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
-      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
+      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/visitor-keys": "5.40.0"
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1075,13 +1096,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
-      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
+      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.40.0",
-        "@typescript-eslint/utils": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1102,9 +1123,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
-      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
+      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1115,13 +1136,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
-      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
+      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/visitor-keys": "5.40.0",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1142,15 +1163,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
-      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
+      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -1167,12 +1189,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
-      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
+      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/types": "5.40.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1396,9 +1418,9 @@
       "dev": true
     },
     "node_modules/bats": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-1.8.0.tgz",
-      "integrity": "sha512-MsaDy16GYvKDXEV2YrdNnMOq6DgcM3LgrCv12ryCi3H9/TWtRAFqinjIZ5Ciy8v0Saa2uA8KDvGn3aVxiirsTA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.8.2.tgz",
+      "integrity": "sha512-KLUIaPYuIMjqui8MbZmK84+CiwhjFVFAhFy5PXP0prLbkovc5faVzc+Qaowbz76F97zP573JrF31ODFAH7vzhg==",
       "dev": true,
       "bin": {
         "bats": "bin/bats"
@@ -1552,9 +1574,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "2.5.19",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.19.tgz",
-      "integrity": "sha512-rDNhNRt0fcZlkoghYcU+OP7vWFEfVu/FEs1V2RgvrHWwOech3NDwgyOQ8uZHwl4YuKKDIrac9hmHTxKryDV1Qg==",
+      "version": "2.5.23",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.23.tgz",
+      "integrity": "sha512-Wf5zJnkBSdQou3ASdBF+NaVqTPpR9S2cnZzDKx78b4KKDsl0rCEG1X6CG41Y2ZIgEUcxgR2X/K6juz9EfprWAw==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -1574,22 +1596,22 @@
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.17.tgz",
-      "integrity": "sha512-vbIsIhvaOaO+UBRFHeylYgch2LgnCyjC/2qh7I2lpJsDae4k3U3tedxFxwGRpKQHqDOPmpb/xfp2nUFSCAL3tA==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.22.tgz",
+      "integrity": "sha512-fGyPyurF8CBecBmVUemObrkvmMkIen7uaJywu7LEXLLEc0eL1AwCkpJOspeMX78ZQfBhLNXb+tsvjHVZomzb+Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^14",
         "ajv": "^8.11.0",
-        "cdk8s": "^2.5.19",
-        "cdk8s-plus-22": "^2.0.0-rc.152",
-        "codemaker": "^1.69.0",
+        "cdk8s": "^2.5.23",
+        "cdk8s-plus-25": "^2.0.0-rc.17",
+        "codemaker": "^1.70.0",
         "colors": "1.4.0",
-        "constructs": "^10.1.131",
+        "constructs": "^10.1.135",
         "fs-extra": "^8",
-        "jsii-pacmak": "^1.69.0",
-        "jsii-srcmak": "^0.1.705",
-        "json2jsii": "^0.3.154",
+        "jsii-pacmak": "^1.70.0",
+        "jsii-srcmak": "^0.1.709",
+        "json2jsii": "^0.3.158",
         "semver": "^7.3.8",
         "sscaff": "^1.2.274",
         "table": "^6.8.0",
@@ -1792,10 +1814,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/cdk8s-plus-22": {
-      "version": "2.0.0-rc.153",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-2.0.0-rc.153.tgz",
-      "integrity": "sha512-9VjYXNj3U6MML9t6mc3EbRME04bGQ7x5F9+jAdMaXT8InEfMJWoLtLgpm3aVGHJsB+8UspfndtIUNqqetEIlqg==",
+    "node_modules/cdk8s-plus-25": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.0-rc.18.tgz",
+      "integrity": "sha512-RG4yVJup/UMFYZTLf+yaJOP0OORcIGx7vo85PKTakiA9WM9kfoGO+6le8vYZllJ9HeIrT4f3TYN8Pt327Dda3g==",
       "bundleDependencies": [
         "minimatch"
       ],
@@ -1807,17 +1829,17 @@
         "node": ">= 14.17.0"
       },
       "peerDependencies": {
-        "cdk8s": "^2.5.19",
-        "constructs": "^10.1.131"
+        "cdk8s": "^2.5.23",
+        "constructs": "^10.1.135"
       }
     },
-    "node_modules/cdk8s-plus-22/node_modules/balanced-match": {
+    "node_modules/cdk8s-plus-25/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/cdk8s-plus-22/node_modules/brace-expansion": {
+    "node_modules/cdk8s-plus-25/node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
       "inBundle": true,
@@ -1827,13 +1849,13 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/cdk8s-plus-22/node_modules/concat-map": {
+    "node_modules/cdk8s-plus-25/node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/cdk8s-plus-22/node_modules/minimatch": {
+    "node_modules/cdk8s-plus-25/node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
       "inBundle": true,
@@ -2046,9 +2068,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.69.0.tgz",
-      "integrity": "sha512-FbJeIr6isHvABZ56wdujvRLQOJOmS6MoptN4ylLKDNr/dp/+tzpa9kY2R2Y7eWxMW5sTYFBNsVJDpErMcMwhig==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.70.0.tgz",
+      "integrity": "sha512-ZiS349YLSwzoe9ZVfupMBd794x3IO4Au6JsyYCchFjbBCzU10TllLigFWSQuVKXBpaBk3I6QhaDuK+JsosDKsg==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2136,9 +2158,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.131",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.131.tgz",
-      "integrity": "sha512-H7p2jsa3aFQK+tuSbXivqdADU5GENtMrnOM5GdYL/9LcCjYc8hsfJBvpaeZA0sixdcILHh/vxJIA7iCtR7keKQ==",
+      "version": "10.1.135",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.135.tgz",
+      "integrity": "sha512-J+DLybfvCNsu4Hyez3cs62/ZprulSH8tpHsXigGiLT708bRrdIqOKiYqCOtZ04BjA22yxUfmC4YqB0hq9sl5MA==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -4205,19 +4227,19 @@
       }
     },
     "node_modules/jsii": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.69.0.tgz",
-      "integrity": "sha512-gusMQ8inlV2/51KsZmZ/H+FeoExrloksgeg8ohvIgF3tvqZKZDh0LvJFGNEeqcJzr+P1OZ3KHVEUI2M0XXicRw==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.70.0.tgz",
+      "integrity": "sha512-RDr/D6IPhCpx5A53qIS99rtwMlDVbjt5F0frCmgalXs2DNiqIm2C8OTUGToVQUrCbX1Lx8eZBmsYWLxG0bQLcg==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.1.0",
-        "log4js": "^6.6.1",
-        "semver": "^7.3.7",
+        "log4js": "^6.7.0",
+        "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "sort-json": "^2.0.1",
         "spdx-license-list": "^6.6.0",
@@ -4232,21 +4254,21 @@
       }
     },
     "node_modules/jsii-pacmak": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.69.0.tgz",
-      "integrity": "sha512-dMNyKOV+5mlRm7nT1UjpbXiYCPwHfiULH0JnBQWpGZBD3k8o9vVbMlV4oecxufTVrZH9DH39Mh+GQjR9yS9g1w==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.70.0.tgz",
+      "integrity": "sha512-BbfIT21BVx1QB1EBLytHxO/CeI+zseI2sp+7wA/Uzfg7U1zS7DoqvsGjZwdl0RvinIJOvkzS55vP5qY5i7btcA==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.69.0",
+        "codemaker": "^1.70.0",
         "commonmark": "^0.30.0",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.69.0",
-        "jsii-rosetta": "^1.69.0",
-        "semver": "^7.3.7",
+        "jsii-reflect": "^1.70.0",
+        "jsii-rosetta": "^1.70.0",
+        "semver": "^7.3.8",
         "spdx-license-list": "^6.6.0",
         "xmlbuilder": "^15.1.1",
         "yargs": "^16.2.0"
@@ -4256,6 +4278,21 @@
       },
       "engines": {
         "node": ">= 14.6.0"
+      }
+    },
+    "node_modules/jsii-pacmak/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsii-pacmak/node_modules/yargs": {
@@ -4277,16 +4314,16 @@
       }
     },
     "node_modules/jsii-reflect": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.69.0.tgz",
-      "integrity": "sha512-gQA4Yu3OlHVmD1X8ysYwgolV5JKS8WbY8p9AKCUQsNbflxUGpYwJrX/Otl+VdiYnIhBZ7+v+VvOG9eYGMUH6IQ==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.70.0.tgz",
+      "integrity": "sha512-1enHoO6/G5o6RB+lzbQEUkXBFoZZRGJCfgYboLcYiH0tITX/FjipeTR9Wgkh9QumwdlBlMTXuxEPyRFVjQ7jcg==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.69.0",
+        "oo-ascii-tree": "^1.70.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -4315,18 +4352,18 @@
       }
     },
     "node_modules/jsii-rosetta": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.69.0.tgz",
-      "integrity": "sha512-zAvvzRShVMmUxNRLtbR4HShGEn17kyiED5XSo1CrVu4JzG6I7YEtYO1WrNFe1XTh76Bbi4OoamZm3Um91DPtXg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.70.0.tgz",
+      "integrity": "sha512-iLfogMZ7tTP0g6iMGPHZOHCjn5+K4agb6oalFYbN8iUXVgf+DwKCOGTIN0TxNpy3YFvb4YhCWVENdYPDu/5Nvw==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "1.69.0",
-        "@xmldom/xmldom": "^0.8.2",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "1.70.0",
+        "@xmldom/xmldom": "^0.8.3",
         "commonmark": "^0.30.0",
         "fast-glob": "^3.2.12",
-        "jsii": "1.69.0",
-        "semver": "^7.3.7",
+        "jsii": "1.70.0",
+        "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "typescript": "~3.9.10",
         "workerpool": "^6.2.1",
@@ -4337,6 +4374,21 @@
       },
       "engines": {
         "node": ">= 14.6.0"
+      }
+    },
+    "node_modules/jsii-rosetta/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsii-rosetta/node_modules/typescript": {
@@ -4371,14 +4423,14 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.705",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.705.tgz",
-      "integrity": "sha512-b6hmOM43VoniG1aAMoGk5MzVZzwOV6rGSyUVdRfBgESnnQErvpqEjaAc8kB9j/isIKcIhoqYHOtERBfObQGpGw==",
+      "version": "0.1.709",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.709.tgz",
+      "integrity": "sha512-GMPn+tyDaJ2yu3Zah6ez5+poAL5UZOiGiMJYcGhjDclV98HUv8whfsot/8tlcMk6mN9231RNmWi3kFT8On1OzA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
-        "jsii": "^1.69.0",
-        "jsii-pacmak": "^1.69.0",
+        "jsii": "^1.70.0",
+        "jsii-pacmak": "^1.70.0",
         "ncp": "^2.0.0",
         "yargs": "^15.4.1"
       },
@@ -4537,6 +4589,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsii/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsii/node_modules/typescript": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -4605,9 +4672,9 @@
       "dev": true
     },
     "node_modules/json2jsii": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.154.tgz",
-      "integrity": "sha512-7KmIIdcydWtGPjxERYhCE5vir8bxDPG5izySZuUyGBhTP937ZwIuxWJmFGsCdqInNws58miByX2jgoAp8MXjLw==",
+      "version": "0.3.158",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.158.tgz",
+      "integrity": "sha512-hhHcDr7eXvRRWNQHxp2PMhb7fGKzkTfk1YKd1wnBgQNOc0Xk7u3gE/DGRQfPsb28tqwQAQ1QwWnL1GTi77Q63A==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -8089,9 +8156,9 @@
       }
     },
     "node_modules/oo-ascii-tree": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.69.0.tgz",
-      "integrity": "sha512-U5bHVg5nC4OHPNd6ZDSotQ1ccRA+4Rb+bWcY+IJuf4imtO3wrJeSDlKVgMf92mwdVDHMZJ3QKJgElCASdr9Bgw==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.70.0.tgz",
+      "integrity": "sha512-vu/NGcQKC6f3fz2C7qmDW1WP2WFK3CvG1JbweyKlnRsZrdbY0VCH9RKsNaoYUTu9tzafCZ4HWeLEkgXALQMsUg==",
       "dev": true,
       "engines": {
         "node": ">= 14.6.0"
@@ -10629,19 +10696,30 @@
       }
     },
     "@jsii/check-node": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.69.0.tgz",
-      "integrity": "sha512-a+g42wsMM1SB91f+/ZGqtEccaCfJkpfbKYczzLM8tN7P00TGHraTFBqd/G6jndRw4mrR+T+3GaAKlzmNLqYIUg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.70.0.tgz",
+      "integrity": "sha512-lebc8VgekEEStNn1K/khkRzs41sjC88tBE0xEkjDpsFNBMXNuek8I9dkaFbjQ9c+P0TsOa17JJUMLxjgCtjW5A==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
-        "semver": "^7.3.7"
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@jsii/spec": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.69.0.tgz",
-      "integrity": "sha512-Dj41jQc6GgbXHyc/IzhmKdrMJSuF7hetRmCkwMvj0/T2WWNAUK/UNNw40QnksfIhB8yooDAoMqGVU/71fbDyaA==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.70.0.tgz",
+      "integrity": "sha512-2l09VaZvT8OLRMwtVm+JxzrzpO6+eR4Scn9B8+zvE9NptX5jN+X68V0VngDuWTJqHs7ntbYCmHQDWuLm0bPr1A==",
       "dev": true,
       "requires": {
         "ajv": "^8.11.0"
@@ -10979,9 +11057,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
-      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
+      "version": "18.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
+      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -11002,15 +11080,21 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
-      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
+      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/type-utils": "5.40.0",
-        "@typescript-eslint/utils": "5.40.0",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/type-utils": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -11019,53 +11103,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
-      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
+      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
-      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
+      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/visitor-keys": "5.40.0"
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
-      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
+      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.40.0",
-        "@typescript-eslint/utils": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/utils": "5.40.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
-      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
+      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
-      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
+      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/visitor-keys": "5.40.0",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/visitor-keys": "5.40.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -11074,27 +11158,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
-      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
+      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.40.0",
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.40.1",
+        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.40.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
-      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
+      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/types": "5.40.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11253,9 +11338,9 @@
       "dev": true
     },
     "bats": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-1.8.0.tgz",
-      "integrity": "sha512-MsaDy16GYvKDXEV2YrdNnMOq6DgcM3LgrCv12ryCi3H9/TWtRAFqinjIZ5Ciy8v0Saa2uA8KDvGn3aVxiirsTA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.8.2.tgz",
+      "integrity": "sha512-KLUIaPYuIMjqui8MbZmK84+CiwhjFVFAhFy5PXP0prLbkovc5faVzc+Qaowbz76F97zP573JrF31ODFAH7vzhg==",
       "dev": true
     },
     "before-after-hook": {
@@ -11374,9 +11459,9 @@
       "dev": true
     },
     "cdk8s": {
-      "version": "2.5.19",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.19.tgz",
-      "integrity": "sha512-rDNhNRt0fcZlkoghYcU+OP7vWFEfVu/FEs1V2RgvrHWwOech3NDwgyOQ8uZHwl4YuKKDIrac9hmHTxKryDV1Qg==",
+      "version": "2.5.23",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.23.tgz",
+      "integrity": "sha512-Wf5zJnkBSdQou3ASdBF+NaVqTPpR9S2cnZzDKx78b4KKDsl0rCEG1X6CG41Y2ZIgEUcxgR2X/K6juz9EfprWAw==",
       "dev": true,
       "requires": {
         "fast-json-patch": "^3.1.1",
@@ -11402,22 +11487,22 @@
       }
     },
     "cdk8s-cli": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.17.tgz",
-      "integrity": "sha512-vbIsIhvaOaO+UBRFHeylYgch2LgnCyjC/2qh7I2lpJsDae4k3U3tedxFxwGRpKQHqDOPmpb/xfp2nUFSCAL3tA==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.22.tgz",
+      "integrity": "sha512-fGyPyurF8CBecBmVUemObrkvmMkIen7uaJywu7LEXLLEc0eL1AwCkpJOspeMX78ZQfBhLNXb+tsvjHVZomzb+Q==",
       "dev": true,
       "requires": {
         "@types/node": "^14",
         "ajv": "^8.11.0",
-        "cdk8s": "^2.5.19",
-        "cdk8s-plus-22": "^2.0.0-rc.152",
-        "codemaker": "^1.69.0",
+        "cdk8s": "^2.5.23",
+        "cdk8s-plus-25": "^2.0.0-rc.17",
+        "codemaker": "^1.70.0",
         "colors": "1.4.0",
-        "constructs": "^10.1.131",
+        "constructs": "^10.1.135",
         "fs-extra": "^8",
-        "jsii-pacmak": "^1.69.0",
-        "jsii-srcmak": "^0.1.705",
-        "json2jsii": "^0.3.154",
+        "jsii-pacmak": "^1.70.0",
+        "jsii-srcmak": "^0.1.709",
+        "json2jsii": "^0.3.158",
         "semver": "^7.3.8",
         "sscaff": "^1.2.274",
         "table": "^6.8.0",
@@ -11574,10 +11659,10 @@
         }
       }
     },
-    "cdk8s-plus-22": {
-      "version": "2.0.0-rc.153",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-22/-/cdk8s-plus-22-2.0.0-rc.153.tgz",
-      "integrity": "sha512-9VjYXNj3U6MML9t6mc3EbRME04bGQ7x5F9+jAdMaXT8InEfMJWoLtLgpm3aVGHJsB+8UspfndtIUNqqetEIlqg==",
+    "cdk8s-plus-25": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.0-rc.18.tgz",
+      "integrity": "sha512-RG4yVJup/UMFYZTLf+yaJOP0OORcIGx7vo85PKTakiA9WM9kfoGO+6le8vYZllJ9HeIrT4f3TYN8Pt327Dda3g==",
       "dev": true,
       "requires": {
         "minimatch": "^3.1.2"
@@ -11730,9 +11815,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.69.0.tgz",
-      "integrity": "sha512-FbJeIr6isHvABZ56wdujvRLQOJOmS6MoptN4ylLKDNr/dp/+tzpa9kY2R2Y7eWxMW5sTYFBNsVJDpErMcMwhig==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.70.0.tgz",
+      "integrity": "sha512-ZiS349YLSwzoe9ZVfupMBd794x3IO4Au6JsyYCchFjbBCzU10TllLigFWSQuVKXBpaBk3I6QhaDuK+JsosDKsg==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -11802,9 +11887,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.131",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.131.tgz",
-      "integrity": "sha512-H7p2jsa3aFQK+tuSbXivqdADU5GENtMrnOM5GdYL/9LcCjYc8hsfJBvpaeZA0sixdcILHh/vxJIA7iCtR7keKQ==",
+      "version": "10.1.135",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.135.tgz",
+      "integrity": "sha512-J+DLybfvCNsu4Hyez3cs62/ZprulSH8tpHsXigGiLT708bRrdIqOKiYqCOtZ04BjA22yxUfmC4YqB0hq9sl5MA==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -13269,19 +13354,19 @@
       }
     },
     "jsii": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.69.0.tgz",
-      "integrity": "sha512-gusMQ8inlV2/51KsZmZ/H+FeoExrloksgeg8ohvIgF3tvqZKZDh0LvJFGNEeqcJzr+P1OZ3KHVEUI2M0XXicRw==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.70.0.tgz",
+      "integrity": "sha512-RDr/D6IPhCpx5A53qIS99rtwMlDVbjt5F0frCmgalXs2DNiqIm2C8OTUGToVQUrCbX1Lx8eZBmsYWLxG0bQLcg==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.1.0",
-        "log4js": "^6.6.1",
-        "semver": "^7.3.7",
+        "log4js": "^6.7.0",
+        "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "sort-json": "^2.0.1",
         "spdx-license-list": "^6.6.0",
@@ -13289,6 +13374,15 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "typescript": {
           "version": "3.9.10",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -13313,26 +13407,35 @@
       }
     },
     "jsii-pacmak": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.69.0.tgz",
-      "integrity": "sha512-dMNyKOV+5mlRm7nT1UjpbXiYCPwHfiULH0JnBQWpGZBD3k8o9vVbMlV4oecxufTVrZH9DH39Mh+GQjR9yS9g1w==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.70.0.tgz",
+      "integrity": "sha512-BbfIT21BVx1QB1EBLytHxO/CeI+zseI2sp+7wA/Uzfg7U1zS7DoqvsGjZwdl0RvinIJOvkzS55vP5qY5i7btcA==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.69.0",
+        "codemaker": "^1.70.0",
         "commonmark": "^0.30.0",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.69.0",
-        "jsii-rosetta": "^1.69.0",
-        "semver": "^7.3.7",
+        "jsii-reflect": "^1.70.0",
+        "jsii-rosetta": "^1.70.0",
+        "semver": "^7.3.8",
         "spdx-license-list": "^6.6.0",
         "xmlbuilder": "^15.1.1",
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "yargs": {
           "version": "16.2.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -13351,16 +13454,16 @@
       }
     },
     "jsii-reflect": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.69.0.tgz",
-      "integrity": "sha512-gQA4Yu3OlHVmD1X8ysYwgolV5JKS8WbY8p9AKCUQsNbflxUGpYwJrX/Otl+VdiYnIhBZ7+v+VvOG9eYGMUH6IQ==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.70.0.tgz",
+      "integrity": "sha512-1enHoO6/G5o6RB+lzbQEUkXBFoZZRGJCfgYboLcYiH0tITX/FjipeTR9Wgkh9QumwdlBlMTXuxEPyRFVjQ7jcg==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "^1.69.0",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "^1.70.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.69.0",
+        "oo-ascii-tree": "^1.70.0",
         "yargs": "^16.2.0"
       },
       "dependencies": {
@@ -13382,24 +13485,33 @@
       }
     },
     "jsii-rosetta": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.69.0.tgz",
-      "integrity": "sha512-zAvvzRShVMmUxNRLtbR4HShGEn17kyiED5XSo1CrVu4JzG6I7YEtYO1WrNFe1XTh76Bbi4OoamZm3Um91DPtXg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.70.0.tgz",
+      "integrity": "sha512-iLfogMZ7tTP0g6iMGPHZOHCjn5+K4agb6oalFYbN8iUXVgf+DwKCOGTIN0TxNpy3YFvb4YhCWVENdYPDu/5Nvw==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.69.0",
-        "@jsii/spec": "1.69.0",
-        "@xmldom/xmldom": "^0.8.2",
+        "@jsii/check-node": "1.70.0",
+        "@jsii/spec": "1.70.0",
+        "@xmldom/xmldom": "^0.8.3",
         "commonmark": "^0.30.0",
         "fast-glob": "^3.2.12",
-        "jsii": "1.69.0",
-        "semver": "^7.3.7",
+        "jsii": "1.70.0",
+        "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "typescript": "~3.9.10",
         "workerpool": "^6.2.1",
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "typescript": {
           "version": "3.9.10",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -13424,14 +13536,14 @@
       }
     },
     "jsii-srcmak": {
-      "version": "0.1.705",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.705.tgz",
-      "integrity": "sha512-b6hmOM43VoniG1aAMoGk5MzVZzwOV6rGSyUVdRfBgESnnQErvpqEjaAc8kB9j/isIKcIhoqYHOtERBfObQGpGw==",
+      "version": "0.1.709",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.709.tgz",
+      "integrity": "sha512-GMPn+tyDaJ2yu3Zah6ez5+poAL5UZOiGiMJYcGhjDclV98HUv8whfsot/8tlcMk6mN9231RNmWi3kFT8On1OzA==",
       "dev": true,
       "requires": {
         "fs-extra": "^9.1.0",
-        "jsii": "^1.69.0",
-        "jsii-pacmak": "^1.69.0",
+        "jsii": "^1.70.0",
+        "jsii-pacmak": "^1.70.0",
         "ncp": "^2.0.0",
         "yargs": "^15.4.1"
       },
@@ -13593,9 +13705,9 @@
       "dev": true
     },
     "json2jsii": {
-      "version": "0.3.154",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.154.tgz",
-      "integrity": "sha512-7KmIIdcydWtGPjxERYhCE5vir8bxDPG5izySZuUyGBhTP937ZwIuxWJmFGsCdqInNws58miByX2jgoAp8MXjLw==",
+      "version": "0.3.158",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.158.tgz",
+      "integrity": "sha512-hhHcDr7eXvRRWNQHxp2PMhb7fGKzkTfk1YKd1wnBgQNOc0Xk7u3gE/DGRQfPsb28tqwQAQ1QwWnL1GTi77Q63A==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -16066,9 +16178,9 @@
       }
     },
     "oo-ascii-tree": {
-      "version": "1.69.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.69.0.tgz",
-      "integrity": "sha512-U5bHVg5nC4OHPNd6ZDSotQ1ccRA+4Rb+bWcY+IJuf4imtO3wrJeSDlKVgMf92mwdVDHMZJ3QKJgElCASdr9Bgw==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.70.0.tgz",
+      "integrity": "sha512-vu/NGcQKC6f3fz2C7qmDW1WP2WFK3CvG1JbweyKlnRsZrdbY0VCH9RKsNaoYUTu9tzafCZ4HWeLEkgXALQMsUg==",
       "dev": true
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "cdk8s": "^2.5.19",
-    "constructs": "^10.1.131"
+    "cdk8s": "^2.5.23",
+    "constructs": "^10.1.135"
   },
   "dependencies": {
     "cron-parser": "4.6.0",
@@ -45,14 +45,14 @@
     "@commitlint/config-conventional": "^17.1.0",
     "@types/lodash": "^4.14.186",
     "@types/mock-fs": "^4.13.1",
-    "@types/node": "^18.11.0",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "bats": "^1.8.0",
+    "@types/node": "^18.11.3",
+    "@typescript-eslint/eslint-plugin": "^5.40.1",
+    "@typescript-eslint/parser": "^5.40.1",
+    "bats": "^1.8.2",
     "c8": "^7.12.0",
-    "cdk8s": "^2.5.19",
-    "cdk8s-cli": "^2.1.17",
-    "constructs": "^10.1.131",
+    "cdk8s": "^2.5.23",
+    "cdk8s-cli": "^2.1.22",
+    "constructs": "^10.1.135",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.1",

--- a/test/web-service/__snapshots__/resque-web.test.ts.snap
+++ b/test/web-service/__snapshots__/resque-web.test.ts.snap
@@ -48,6 +48,7 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
@@ -131,6 +132,16 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
             {
               "image": "talis/resque-web:stable",
               "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "name": "resque",
               "ports": [
                 {
@@ -138,6 +149,16 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
                   "protocol": "TCP",
                 },
               ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -147,6 +168,15 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
                   "cpu": "50m",
                   "memory": "100Mi",
                 },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
               },
             },
           ],
@@ -206,6 +236,7 @@ exports[`ResqueWeb > Customizations 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
@@ -318,6 +349,16 @@ exports[`ResqueWeb > Customizations 1`] = `
               ],
               "image": "talis/resque-web:latest",
               "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "name": "resque",
               "ports": [
                 {
@@ -325,6 +366,16 @@ exports[`ResqueWeb > Customizations 1`] = `
                   "protocol": "TCP",
                 },
               ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -334,6 +385,15 @@ exports[`ResqueWeb > Customizations 1`] = `
                   "cpu": "50m",
                   "memory": "100Mi",
                 },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
               },
             },
           ],

--- a/test/web-service/__snapshots__/resque-web.test.ts.snap
+++ b/test/web-service/__snapshots__/resque-web.test.ts.snap
@@ -404,3 +404,405 @@ exports[`ResqueWeb > Customizations 1`] = `
   },
 ]
 `;
+
+exports[`ResqueWeb > ingressAnnotations are merged 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "annotations": {
+        "talis.io/chat": "https://talis.slack.com/archives/C04P9DPCX",
+        "talis.io/description": "Frontend to the Resque job queue system",
+        "talis.io/eks-dashboard": "None",
+        "talis.io/graphs": "None",
+        "talis.io/incidents": "None",
+        "talis.io/issues": "https://github.com/talis/platform/issues",
+        "talis.io/logs": "None",
+        "talis.io/repository": "https://github.com/talis/resque-web-container",
+        "talis.io/runbook": "None",
+        "talis.io/uptime": "None",
+        "talis.io/url": "http://resque.example.com",
+      },
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+      },
+      "name": "test-resque-web-resque-web-service-c81bf306",
+    },
+    "spec": {
+      "ports": [
+        {
+          "port": 3000,
+          "protocol": "TCP",
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "resque",
+        "instance": "resque-web",
+        "role": "server",
+      },
+      "type": "NodePort",
+    },
+  },
+  {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "Ingress",
+    "metadata": {
+      "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
+        "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
+        "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
+        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
+        "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
+        "alb.ingress.kubernetes.io/ssl-redirect": "443",
+        "alb.ingress.kubernetes.io/success-codes": "200,303",
+        "alb.ingress.kubernetes.io/tags": "service=resque,instance=resque-web",
+        "alb.ingress.kubernetes.io/target-type": "instance",
+        "talis.io/foo": "bar",
+      },
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+      },
+      "name": "test-resque-web-resque-web-ingress-c8c81984",
+    },
+    "spec": {
+      "defaultBackend": {
+        "service": {
+          "name": "test-resque-web-resque-web-service-c81bf306",
+          "port": {
+            "number": 3000,
+          },
+        },
+      },
+      "ingressClassName": "aws-load-balancer-internal",
+      "tls": [
+        {
+          "hosts": [
+            "*.example.com",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+      },
+      "name": "test-resque-web-c82b282b",
+    },
+    "spec": {
+      "replicas": 1,
+      "revisionHistoryLimit": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "resque",
+          "instance": "resque-web",
+          "role": "server",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "resque",
+            "instance": "resque-web",
+            "release": "stable",
+            "role": "server",
+          },
+        },
+        "spec": {
+          "affinity": {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchLabels": {
+                        "app": "resque",
+                        "instance": "resque-web",
+                        "role": "server",
+                      },
+                    },
+                    "topologyKey": "topology.kubernetes.io/zone",
+                  },
+                  "weight": 100,
+                },
+              ],
+            },
+          },
+          "automountServiceAccountToken": false,
+          "containers": [
+            {
+              "image": "talis/resque-web:stable",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
+              "name": "resque",
+              "ports": [
+                {
+                  "containerPort": 3000,
+                  "protocol": "TCP",
+                },
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "200Mi",
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "100Mi",
+                },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
+              },
+            },
+          ],
+          "priorityClassName": "web",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`ResqueWeb > selectorLabels are merged 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "annotations": {
+        "talis.io/chat": "https://talis.slack.com/archives/C04P9DPCX",
+        "talis.io/description": "Frontend to the Resque job queue system",
+        "talis.io/eks-dashboard": "None",
+        "talis.io/graphs": "None",
+        "talis.io/incidents": "None",
+        "talis.io/issues": "https://github.com/talis/platform/issues",
+        "talis.io/logs": "None",
+        "talis.io/repository": "https://github.com/talis/resque-web-container",
+        "talis.io/runbook": "None",
+        "talis.io/uptime": "None",
+        "talis.io/url": "http://resque.example.com",
+      },
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+        "test": "true",
+      },
+      "name": "test-resque-web-resque-web-service-c81bf306",
+    },
+    "spec": {
+      "ports": [
+        {
+          "port": 3000,
+          "protocol": "TCP",
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "resque",
+        "instance": "resque-web",
+        "role": "server",
+        "test": "true",
+      },
+      "type": "NodePort",
+    },
+  },
+  {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "Ingress",
+    "metadata": {
+      "annotations": {
+        "alb.ingress.kubernetes.io/healthcheck-path": "/status",
+        "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
+        "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
+        "alb.ingress.kubernetes.io/load-balancer-name": "resque-web-develop",
+        "alb.ingress.kubernetes.io/ssl-policy": "ELBSecurityPolicy-TLS-1-2-2017-01",
+        "alb.ingress.kubernetes.io/ssl-redirect": "443",
+        "alb.ingress.kubernetes.io/success-codes": "200,303",
+        "alb.ingress.kubernetes.io/tags": "service=resque,instance=resque-web",
+        "alb.ingress.kubernetes.io/target-type": "instance",
+      },
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+        "test": "true",
+      },
+      "name": "test-resque-web-resque-web-ingress-c8c81984",
+    },
+    "spec": {
+      "defaultBackend": {
+        "service": {
+          "name": "test-resque-web-resque-web-service-c81bf306",
+          "port": {
+            "number": 3000,
+          },
+        },
+      },
+      "ingressClassName": "aws-load-balancer-internal",
+      "tls": [
+        {
+          "hosts": [
+            "*.example.com",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app": "resque",
+        "instance": "resque-web",
+        "release": "stable",
+        "role": "server",
+        "test": "true",
+      },
+      "name": "test-resque-web-c82b282b",
+    },
+    "spec": {
+      "replicas": 1,
+      "revisionHistoryLimit": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "resque",
+          "instance": "resque-web",
+          "role": "server",
+          "test": "true",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "resque",
+            "instance": "resque-web",
+            "release": "stable",
+            "role": "server",
+            "test": "true",
+          },
+        },
+        "spec": {
+          "affinity": {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchLabels": {
+                        "app": "resque",
+                        "instance": "resque-web",
+                        "role": "server",
+                        "test": "true",
+                      },
+                    },
+                    "topologyKey": "topology.kubernetes.io/zone",
+                  },
+                  "weight": 100,
+                },
+              ],
+            },
+          },
+          "automountServiceAccountToken": false,
+          "containers": [
+            {
+              "image": "talis/resque-web:stable",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
+              "name": "resque",
+              "ports": [
+                {
+                  "containerPort": 3000,
+                  "protocol": "TCP",
+                },
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 5,
+                "successThreshold": 1,
+                "timeoutSeconds": 1,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "200Mi",
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "100Mi",
+                },
+              },
+              "startupProbe": {
+                "failureThreshold": 30,
+                "httpGet": {
+                  "path": "/status",
+                  "port": 3000,
+                },
+                "periodSeconds": 2,
+                "timeoutSeconds": 1,
+              },
+            },
+          ],
+          "priorityClassName": "web",
+        },
+      },
+    },
+  },
+]
+`;

--- a/test/web-service/resque-web.test.ts
+++ b/test/web-service/resque-web.test.ts
@@ -35,4 +35,30 @@ describe("ResqueWeb", () => {
     const results = Testing.synth(chart);
     expect(results).toMatchSnapshot();
   });
+
+  test("selectorLabels are merged", () => {
+    const chart = Testing.chart();
+    new ResqueWeb(chart, "resque-web", {
+      externalUrl: "http://resque.example.com",
+      tlsDomain: "*.example.com",
+      selectorLabels: {
+        test: "true",
+      },
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
+
+  test("ingressAnnotations are merged", () => {
+    const chart = Testing.chart();
+    new ResqueWeb(chart, "resque-web", {
+      externalUrl: "http://resque.example.com",
+      tlsDomain: "*.example.com",
+      ingressAnnotations: {
+        "talis.io/foo": "bar",
+      },
+    });
+    const results = Testing.synth(chart);
+    expect(results).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
- The `talis/resque-web` container image now includes a `/status` endpoint, this adds Pod probes and configures ALB's health check to use that.
- Fix how overriding nested props works.