### PR TITLE
feat: restrict server-status endpoint

### DIFF
--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -241,6 +241,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-develop",
@@ -273,6 +274,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -335,6 +356,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-c-develop",
@@ -367,6 +389,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -802,6 +844,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-develop",
@@ -834,6 +877,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -1116,6 +1179,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-c-develop",
@@ -1148,6 +1212,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -1583,6 +1667,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-develop",
@@ -1615,6 +1700,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -1677,6 +1782,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-c-develop",
@@ -1709,6 +1815,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -2143,6 +2269,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-develop",
@@ -2175,6 +2302,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -2457,6 +2604,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-c-develop",
@@ -2489,6 +2637,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -2923,6 +3091,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-develop",
@@ -2955,6 +3124,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -3017,6 +3206,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "advanced-test-web-c-develop",
@@ -3049,6 +3239,26 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [

--- a/examples/background-worker/__snapshots__/chart.test.ts.snap
+++ b/examples/background-worker/__snapshots__/chart.test.ts.snap
@@ -109,6 +109,7 @@ exports[`BackgroundWorker example > Change release version 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -142,6 +143,26 @@ exports[`BackgroundWorker example > Change release version 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -508,6 +529,7 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -541,6 +563,26 @@ exports[`BackgroundWorker example > Snapshot 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [

--- a/examples/simple-web-service/__snapshots__/main.test.ts.snap
+++ b/examples/simple-web-service/__snapshots__/main.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Simple WebService example > Snapshot 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "web-develop",
@@ -71,6 +72,26 @@ exports[`Simple WebService example > Snapshot 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [

--- a/test/web-service/__snapshots__/resque-web.test.ts.snap
+++ b/test/web-service/__snapshots__/resque-web.test.ts.snap
@@ -48,6 +48,7 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -74,6 +75,26 @@ exports[`ResqueWeb > Creates resque web objects 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
     },
   },
   {
@@ -236,6 +257,7 @@ exports[`ResqueWeb > Customizations 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -265,6 +287,26 @@ exports[`ResqueWeb > Customizations 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -453,6 +495,7 @@ exports[`ResqueWeb > ingressAnnotations are merged 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -482,6 +525,26 @@ exports[`ResqueWeb > ingressAnnotations are merged 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -653,6 +716,7 @@ exports[`ResqueWeb > selectorLabels are merged 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/status",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
@@ -682,6 +746,26 @@ exports[`ResqueWeb > selectorLabels are merged 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internal",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -120,6 +120,7 @@ exports[`WebService > Props > All the props 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/ping",
         "alb.ingress.kubernetes.io/ip-address-type": "dualstack",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
@@ -169,6 +170,24 @@ exports[`WebService > Props > All the props 1`] = `
                   },
                 },
                 "path": "/",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
                 "pathType": "Prefix",
               },
             ],
@@ -534,6 +553,7 @@ exports[`WebService > Props > All the props 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/healthcheck-path": "/ping",
         "alb.ingress.kubernetes.io/ip-address-type": "dualstack",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80},{\\"HTTPS\\":443}]",
@@ -567,6 +587,26 @@ exports[`WebService > Props > All the props 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
       "tls": [
         {
           "hosts": [
@@ -913,6 +953,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
@@ -938,6 +979,26 @@ exports[`WebService > Props > Horizontal Pod Autoscaler 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
     },
   },
   {
@@ -1095,6 +1156,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for both memory and cpu 
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
@@ -1120,6 +1182,26 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for both memory and cpu 
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
     },
   },
   {
@@ -1287,6 +1369,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for memory 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
@@ -1312,6 +1395,26 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for memory 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
     },
   },
   {
@@ -1473,6 +1576,7 @@ exports[`WebService > Props > Minimal required props 1`] = `
     "kind": "Ingress",
     "metadata": {
       "annotations": {
+        "alb.ingress.kubernetes.io/actions.server-status-rule": "{\\"type\\":\\"fixed-response\\",\\"fixedResponseConfig\\":{\\"statusCode\\":\\"404\\",\\"contentType\\":\\"text/plain\\",\\"messageBody\\":\\"404: Not Found\\"}}",
         "alb.ingress.kubernetes.io/listen-ports": "[{\\"HTTP\\":80}]",
         "alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=60",
         "alb.ingress.kubernetes.io/load-balancer-name": "test-web-develop",
@@ -1498,6 +1602,26 @@ exports[`WebService > Props > Minimal required props 1`] = `
         },
       },
       "ingressClassName": "aws-load-balancer-internet-facing",
+      "rules": [
+        {
+          "http": {
+            "paths": [
+              {
+                "backend": {
+                  "service": {
+                    "name": "server-status-rule",
+                    "port": {
+                      "name": "use-annotation",
+                    },
+                  },
+                },
+                "path": "/server-status",
+                "pathType": "Prefix",
+              },
+            ],
+          },
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Updates the web service construct to have an ingress rule for the `/server-status` endpoint and adds an ALB rule to return a fixed 404 from the ALB for this.

This should still allow instana internal to the cluster and talking to the pods directly to get the `/server-status` endpoint but prevent any traffic coming via the ingress to access this.