### PR TITLE
feat: update Kubernetes schema

### DIFF
--- a/e2e/full-stack.e2e.ts
+++ b/e2e/full-stack.e2e.ts
@@ -5,6 +5,7 @@ import {
   Container,
   EnvFromSource,
   IntOrString,
+  IoK8SApiCoreV1PodSpecRestartPolicy,
   Quantity,
   ResourceRequirements,
 } from "../imports/k8s";
@@ -116,7 +117,7 @@ export class FullStackChart extends TalisChart {
       image: busyboxImage,
       release: busyboxVersion,
       command: ["sh", "-c", "echo 'hello world'"],
-      restartPolicy: "Never",
+      restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
       resources: commonResources,
     });
 
@@ -125,7 +126,7 @@ export class FullStackChart extends TalisChart {
       image: `docker.io/mongo:${mongoVersion}`,
       release: mongoVersion,
       command: ["mongo", `--host=${mongoHost}`, "--eval", "db.stats()"],
-      restartPolicy: "Never",
+      restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
       resources: commonResources,
     });
 

--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -1088,7 +1088,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {
@@ -2513,7 +2513,7 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {

--- a/examples/cron-job/chart.ts
+++ b/examples/cron-job/chart.ts
@@ -6,7 +6,10 @@ import {
   TalisChart,
   TalisChartProps,
 } from "../../lib";
-import { Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  Quantity,
+} from "../../imports/k8s";
 
 export class CronJobChart extends TalisChart {
   constructor(scope: Construct, props: TalisChartProps) {
@@ -17,7 +20,7 @@ export class CronJobChart extends TalisChart {
 
     new CronJob(this, "cron-job-example", {
       schedule: "0 0 13 * 5",
-      restartPolicy: "Never",
+      restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
       image: `docker.io/organization/my-app:cron-${release}`,
       imagePullSecrets: [{ name: dockerHubSecret.name }],
       release,

--- a/examples/job/chart.ts
+++ b/examples/job/chart.ts
@@ -6,7 +6,10 @@ import {
   TalisChart,
   TalisChartProps,
 } from "../../lib";
-import { Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  Quantity,
+} from "../../imports/k8s";
 
 export class JobChart extends TalisChart {
   constructor(scope: Construct, props: TalisChartProps) {
@@ -16,7 +19,7 @@ export class JobChart extends TalisChart {
     const dockerHubSecret = createDockerHubSecretFromEnv(this);
 
     new Job(this, "job-example", {
-      restartPolicy: "OnFailure",
+      restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.ON_FAILURE,
       ttlSecondsAfterFinished: 100,
       image: `docker.io/organization/my-app:job-${release}`,
       imagePullSecrets: [{ name: dockerHubSecret.name }],

--- a/imports/k8s.ts
+++ b/imports/k8s.ts
@@ -1359,6 +1359,114 @@ export class KubeScale extends ApiObject {
 /**
  * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
  *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
+ */
+export class KubeHorizontalPodAutoscalerV2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'autoscaling/v2',
+    kind: 'HorizontalPodAutoscaler',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubeHorizontalPodAutoscalerV2Props = {}): any {
+    return {
+      ...KubeHorizontalPodAutoscalerV2.GVK,
+      ...toJson_KubeHorizontalPodAutoscalerV2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubeHorizontalPodAutoscalerV2Props = {}) {
+    super(scope, id, {
+      ...KubeHorizontalPodAutoscalerV2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubeHorizontalPodAutoscalerV2.GVK,
+      ...toJson_KubeHorizontalPodAutoscalerV2Props(resolved),
+    };
+  }
+}
+
+/**
+ * HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
+ *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList
+ */
+export class KubeHorizontalPodAutoscalerListV2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'autoscaling/v2',
+    kind: 'HorizontalPodAutoscalerList',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubeHorizontalPodAutoscalerListV2Props): any {
+    return {
+      ...KubeHorizontalPodAutoscalerListV2.GVK,
+      ...toJson_KubeHorizontalPodAutoscalerListV2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubeHorizontalPodAutoscalerListV2Props) {
+    super(scope, id, {
+      ...KubeHorizontalPodAutoscalerListV2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubeHorizontalPodAutoscalerListV2.GVK,
+      ...toJson_KubeHorizontalPodAutoscalerListV2Props(resolved),
+    };
+  }
+}
+
+/**
+ * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+ *
  * @schema io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler
  */
 export class KubeHorizontalPodAutoscalerV2Beta1 extends ApiObject {
@@ -4452,6 +4560,222 @@ export class KubePriorityLevelConfigurationListV1Beta1 extends ApiObject {
 }
 
 /**
+ * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchema
+ */
+export class KubeFlowSchemaV1Beta2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.flowcontrol.v1beta2.FlowSchema"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
+    kind: 'FlowSchema',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchema".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubeFlowSchemaV1Beta2Props = {}): any {
+    return {
+      ...KubeFlowSchemaV1Beta2.GVK,
+      ...toJson_KubeFlowSchemaV1Beta2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.flowcontrol.v1beta2.FlowSchema" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubeFlowSchemaV1Beta2Props = {}) {
+    super(scope, id, {
+      ...KubeFlowSchemaV1Beta2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubeFlowSchemaV1Beta2.GVK,
+      ...toJson_KubeFlowSchemaV1Beta2Props(resolved),
+    };
+  }
+}
+
+/**
+ * FlowSchemaList is a list of FlowSchema objects.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaList
+ */
+export class KubeFlowSchemaListV1Beta2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
+    kind: 'FlowSchemaList',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubeFlowSchemaListV1Beta2Props): any {
+    return {
+      ...KubeFlowSchemaListV1Beta2.GVK,
+      ...toJson_KubeFlowSchemaListV1Beta2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubeFlowSchemaListV1Beta2Props) {
+    super(scope, id, {
+      ...KubeFlowSchemaListV1Beta2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubeFlowSchemaListV1Beta2.GVK,
+      ...toJson_KubeFlowSchemaListV1Beta2Props(resolved),
+    };
+  }
+}
+
+/**
+ * PriorityLevelConfiguration represents the configuration of a priority level.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration
+ */
+export class KubePriorityLevelConfigurationV1Beta2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
+    kind: 'PriorityLevelConfiguration',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubePriorityLevelConfigurationV1Beta2Props = {}): any {
+    return {
+      ...KubePriorityLevelConfigurationV1Beta2.GVK,
+      ...toJson_KubePriorityLevelConfigurationV1Beta2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubePriorityLevelConfigurationV1Beta2Props = {}) {
+    super(scope, id, {
+      ...KubePriorityLevelConfigurationV1Beta2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubePriorityLevelConfigurationV1Beta2.GVK,
+      ...toJson_KubePriorityLevelConfigurationV1Beta2Props(resolved),
+    };
+  }
+}
+
+/**
+ * PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList
+ */
+export class KubePriorityLevelConfigurationListV1Beta2 extends ApiObject {
+  /**
+   * Returns the apiVersion and kind for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList"
+   */
+  public static readonly GVK: GroupVersionKind = {
+    apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
+    kind: 'PriorityLevelConfigurationList',
+  }
+
+  /**
+   * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList".
+   *
+   * This can be used to inline resource manifests inside other objects (e.g. as templates).
+   *
+   * @param props initialization props
+   */
+  public static manifest(props: KubePriorityLevelConfigurationListV1Beta2Props): any {
+    return {
+      ...KubePriorityLevelConfigurationListV1Beta2.GVK,
+      ...toJson_KubePriorityLevelConfigurationListV1Beta2Props(props),
+    };
+  }
+
+  /**
+   * Defines a "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList" API object
+   * @param scope the scope in which to define this object
+   * @param id a scope-local name for the object
+   * @param props initialization props
+   */
+  public constructor(scope: Construct, id: string, props: KubePriorityLevelConfigurationListV1Beta2Props) {
+    super(scope, id, {
+      ...KubePriorityLevelConfigurationListV1Beta2.GVK,
+      ...props,
+    });
+  }
+
+  /**
+   * Renders the object to Kubernetes JSON.
+   */
+  public toJson(): any {
+    const resolved = super.toJson();
+
+    return {
+      ...KubePriorityLevelConfigurationListV1Beta2.GVK,
+      ...toJson_KubePriorityLevelConfigurationListV1Beta2Props(resolved),
+    };
+  }
+}
+
+/**
  * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
  *
  * @schema io.k8s.api.networking.v1.Ingress
@@ -5910,438 +6234,6 @@ export class KubeRoleList extends ApiObject {
 }
 
 /**
- * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRole
- */
-export class KubeClusterRoleV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.ClusterRole"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'ClusterRole',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.ClusterRole".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeClusterRoleV1Alpha1Props = {}): any {
-    return {
-      ...KubeClusterRoleV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.ClusterRole" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeClusterRoleV1Alpha1Props = {}) {
-    super(scope, id, {
-      ...KubeClusterRoleV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeClusterRoleV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
- */
-export class KubeClusterRoleBindingV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'ClusterRoleBinding',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeClusterRoleBindingV1Alpha1Props): any {
-    return {
-      ...KubeClusterRoleBindingV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleBindingV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeClusterRoleBindingV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeClusterRoleBindingV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeClusterRoleBindingV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleBindingV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindings, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList
- */
-export class KubeClusterRoleBindingListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'ClusterRoleBindingList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeClusterRoleBindingListV1Alpha1Props): any {
-    return {
-      ...KubeClusterRoleBindingListV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleBindingListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeClusterRoleBindingListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeClusterRoleBindingListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeClusterRoleBindingListV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleBindingListV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleList
- */
-export class KubeClusterRoleListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.ClusterRoleList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'ClusterRoleList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.ClusterRoleList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeClusterRoleListV1Alpha1Props): any {
-    return {
-      ...KubeClusterRoleListV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.ClusterRoleList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeClusterRoleListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeClusterRoleListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeClusterRoleListV1Alpha1.GVK,
-      ...toJson_KubeClusterRoleListV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.Role
- */
-export class KubeRoleV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.Role"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'Role',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.Role".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeRoleV1Alpha1Props = {}): any {
-    return {
-      ...KubeRoleV1Alpha1.GVK,
-      ...toJson_KubeRoleV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.Role" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeRoleV1Alpha1Props = {}) {
-    super(scope, id, {
-      ...KubeRoleV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeRoleV1Alpha1.GVK,
-      ...toJson_KubeRoleV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleBinding
- */
-export class KubeRoleBindingV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.RoleBinding"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'RoleBinding',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.RoleBinding".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeRoleBindingV1Alpha1Props): any {
-    return {
-      ...KubeRoleBindingV1Alpha1.GVK,
-      ...toJson_KubeRoleBindingV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.RoleBinding" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeRoleBindingV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeRoleBindingV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeRoleBindingV1Alpha1.GVK,
-      ...toJson_KubeRoleBindingV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleBindingList
- */
-export class KubeRoleBindingListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.RoleBindingList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'RoleBindingList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.RoleBindingList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeRoleBindingListV1Alpha1Props): any {
-    return {
-      ...KubeRoleBindingListV1Alpha1.GVK,
-      ...toJson_KubeRoleBindingListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.RoleBindingList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeRoleBindingListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeRoleBindingListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeRoleBindingListV1Alpha1.GVK,
-      ...toJson_KubeRoleBindingListV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * RoleList is a collection of Roles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleList
- */
-export class KubeRoleListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.rbac.v1alpha1.RoleList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'rbac.authorization.k8s.io/v1alpha1',
-    kind: 'RoleList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1alpha1.RoleList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeRoleListV1Alpha1Props): any {
-    return {
-      ...KubeRoleListV1Alpha1.GVK,
-      ...toJson_KubeRoleListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.rbac.v1alpha1.RoleList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeRoleListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeRoleListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeRoleListV1Alpha1.GVK,
-      ...toJson_KubeRoleListV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
  * PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  *
  * @schema io.k8s.api.scheduling.v1.PriorityClass
@@ -6445,114 +6337,6 @@ export class KubePriorityClassList extends ApiObject {
     return {
       ...KubePriorityClassList.GVK,
       ...toJson_KubePriorityClassListProps(resolved),
-    };
-  }
-}
-
-/**
- * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
- *
- * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass
- */
-export class KubePriorityClassV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.scheduling.v1alpha1.PriorityClass"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'scheduling.k8s.io/v1alpha1',
-    kind: 'PriorityClass',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1alpha1.PriorityClass".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubePriorityClassV1Alpha1Props): any {
-    return {
-      ...KubePriorityClassV1Alpha1.GVK,
-      ...toJson_KubePriorityClassV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.scheduling.v1alpha1.PriorityClass" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubePriorityClassV1Alpha1Props) {
-    super(scope, id, {
-      ...KubePriorityClassV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubePriorityClassV1Alpha1.GVK,
-      ...toJson_KubePriorityClassV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * PriorityClassList is a collection of priority classes.
- *
- * @schema io.k8s.api.scheduling.v1alpha1.PriorityClassList
- */
-export class KubePriorityClassListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.scheduling.v1alpha1.PriorityClassList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'scheduling.k8s.io/v1alpha1',
-    kind: 'PriorityClassList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1alpha1.PriorityClassList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubePriorityClassListV1Alpha1Props): any {
-    return {
-      ...KubePriorityClassListV1Alpha1.GVK,
-      ...toJson_KubePriorityClassListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.scheduling.v1alpha1.PriorityClassList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubePriorityClassListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubePriorityClassListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubePriorityClassListV1Alpha1.GVK,
-      ...toJson_KubePriorityClassListV1Alpha1Props(resolved),
     };
   }
 }
@@ -7105,116 +6889,6 @@ export class KubeCsiStorageCapacityListV1Alpha1 extends ApiObject {
     return {
       ...KubeCsiStorageCapacityListV1Alpha1.GVK,
       ...toJson_KubeCsiStorageCapacityListV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
-
-VolumeAttachment objects are non-namespaced.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachment
- */
-export class KubeVolumeAttachmentV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.storage.v1alpha1.VolumeAttachment"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'storage.k8s.io/v1alpha1',
-    kind: 'VolumeAttachment',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.storage.v1alpha1.VolumeAttachment".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeVolumeAttachmentV1Alpha1Props): any {
-    return {
-      ...KubeVolumeAttachmentV1Alpha1.GVK,
-      ...toJson_KubeVolumeAttachmentV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.storage.v1alpha1.VolumeAttachment" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeVolumeAttachmentV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeVolumeAttachmentV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeVolumeAttachmentV1Alpha1.GVK,
-      ...toJson_KubeVolumeAttachmentV1Alpha1Props(resolved),
-    };
-  }
-}
-
-/**
- * VolumeAttachmentList is a collection of VolumeAttachment objects.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentList
- */
-export class KubeVolumeAttachmentListV1Alpha1 extends ApiObject {
-  /**
-   * Returns the apiVersion and kind for "io.k8s.api.storage.v1alpha1.VolumeAttachmentList"
-   */
-  public static readonly GVK: GroupVersionKind = {
-    apiVersion: 'storage.k8s.io/v1alpha1',
-    kind: 'VolumeAttachmentList',
-  }
-
-  /**
-   * Renders a Kubernetes manifest for "io.k8s.api.storage.v1alpha1.VolumeAttachmentList".
-   *
-   * This can be used to inline resource manifests inside other objects (e.g. as templates).
-   *
-   * @param props initialization props
-   */
-  public static manifest(props: KubeVolumeAttachmentListV1Alpha1Props): any {
-    return {
-      ...KubeVolumeAttachmentListV1Alpha1.GVK,
-      ...toJson_KubeVolumeAttachmentListV1Alpha1Props(props),
-    };
-  }
-
-  /**
-   * Defines a "io.k8s.api.storage.v1alpha1.VolumeAttachmentList" API object
-   * @param scope the scope in which to define this object
-   * @param id a scope-local name for the object
-   * @param props initialization props
-   */
-  public constructor(scope: Construct, id: string, props: KubeVolumeAttachmentListV1Alpha1Props) {
-    super(scope, id, {
-      ...KubeVolumeAttachmentListV1Alpha1.GVK,
-      ...props,
-    });
-  }
-
-  /**
-   * Renders the object to Kubernetes JSON.
-   */
-  public toJson(): any {
-    const resolved = super.toJson();
-
-    return {
-      ...KubeVolumeAttachmentListV1Alpha1.GVK,
-      ...toJson_KubeVolumeAttachmentListV1Alpha1Props(resolved),
     };
   }
 }
@@ -8536,6 +8210,80 @@ export function toJson_KubeScaleProps(obj: KubeScaleProps | undefined): Record<s
   const result = {
     'metadata': toJson_ObjectMeta(obj.metadata),
     'spec': toJson_ScaleSpec(obj.spec),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+ *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler
+ */
+export interface KubeHorizontalPodAutoscalerV2Props {
+  /**
+   * metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler#metadata
+   */
+  readonly metadata?: ObjectMeta;
+
+  /**
+   * spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler#spec
+   */
+  readonly spec?: HorizontalPodAutoscalerSpecV2;
+
+}
+
+/**
+ * Converts an object of type 'KubeHorizontalPodAutoscalerV2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubeHorizontalPodAutoscalerV2Props(obj: KubeHorizontalPodAutoscalerV2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'metadata': toJson_ObjectMeta(obj.metadata),
+    'spec': toJson_HorizontalPodAutoscalerSpecV2(obj.spec),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
+ *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList
+ */
+export interface KubeHorizontalPodAutoscalerListV2Props {
+  /**
+   * items is the list of horizontal pod autoscaler objects.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList#items
+   */
+  readonly items: KubeHorizontalPodAutoscalerV2Props[];
+
+  /**
+   * metadata is the standard list metadata.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList#metadata
+   */
+  readonly metadata?: ListMeta;
+
+}
+
+/**
+ * Converts an object of type 'KubeHorizontalPodAutoscalerListV2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubeHorizontalPodAutoscalerListV2Props(obj: KubeHorizontalPodAutoscalerListV2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'items': obj.items?.map(y => toJson_KubeHorizontalPodAutoscalerV2Props(y)),
+    'metadata': toJson_ListMeta(obj.metadata),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -10227,7 +9975,7 @@ export interface KubeSecretProps {
   readonly stringData?: { [key: string]: string };
 
   /**
-   * Used to facilitate programmatic handling of secret data.
+   * Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
    *
    * @schema io.k8s.api.core.v1.Secret#type
    */
@@ -10463,9 +10211,14 @@ export interface KubeEndpointSliceProps {
   /**
    * addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
    *
+   * Possible enum values:
+   * - `"FQDN"` represents a FQDN.
+   * - `"IPv4"` represents an IPv4 Address.
+   * - `"IPv6"` represents an IPv6 Address.
+   *
    * @schema io.k8s.api.discovery.v1.EndpointSlice#addressType
    */
-  readonly addressType: string;
+  readonly addressType: IoK8SApiDiscoveryV1EndpointSliceAddressType;
 
   /**
    * endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
@@ -10953,6 +10706,154 @@ export function toJson_KubePriorityLevelConfigurationListV1Beta1Props(obj: KubeP
   if (obj === undefined) { return undefined; }
   const result = {
     'items': obj.items?.map(y => toJson_KubePriorityLevelConfigurationV1Beta1Props(y)),
+    'metadata': toJson_ListMeta(obj.metadata),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchema
+ */
+export interface KubeFlowSchemaV1Beta2Props {
+  /**
+   * `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchema#metadata
+   */
+  readonly metadata?: ObjectMeta;
+
+  /**
+   * `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchema#spec
+   */
+  readonly spec?: FlowSchemaSpecV1Beta2;
+
+}
+
+/**
+ * Converts an object of type 'KubeFlowSchemaV1Beta2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubeFlowSchemaV1Beta2Props(obj: KubeFlowSchemaV1Beta2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'metadata': toJson_ObjectMeta(obj.metadata),
+    'spec': toJson_FlowSchemaSpecV1Beta2(obj.spec),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * FlowSchemaList is a list of FlowSchema objects.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaList
+ */
+export interface KubeFlowSchemaListV1Beta2Props {
+  /**
+   * `items` is a list of FlowSchemas.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaList#items
+   */
+  readonly items: KubeFlowSchemaV1Beta2Props[];
+
+  /**
+   * `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaList#metadata
+   */
+  readonly metadata?: ListMeta;
+
+}
+
+/**
+ * Converts an object of type 'KubeFlowSchemaListV1Beta2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubeFlowSchemaListV1Beta2Props(obj: KubeFlowSchemaListV1Beta2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'items': obj.items?.map(y => toJson_KubeFlowSchemaV1Beta2Props(y)),
+    'metadata': toJson_ListMeta(obj.metadata),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PriorityLevelConfiguration represents the configuration of a priority level.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration
+ */
+export interface KubePriorityLevelConfigurationV1Beta2Props {
+  /**
+   * `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration#metadata
+   */
+  readonly metadata?: ObjectMeta;
+
+  /**
+   * `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration#spec
+   */
+  readonly spec?: PriorityLevelConfigurationSpecV1Beta2;
+
+}
+
+/**
+ * Converts an object of type 'KubePriorityLevelConfigurationV1Beta2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubePriorityLevelConfigurationV1Beta2Props(obj: KubePriorityLevelConfigurationV1Beta2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'metadata': toJson_ObjectMeta(obj.metadata),
+    'spec': toJson_PriorityLevelConfigurationSpecV1Beta2(obj.spec),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList
+ */
+export interface KubePriorityLevelConfigurationListV1Beta2Props {
+  /**
+   * `items` is a list of request-priorities.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList#items
+   */
+  readonly items: KubePriorityLevelConfigurationV1Beta2Props[];
+
+  /**
+   * `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList#metadata
+   */
+  readonly metadata?: ListMeta;
+
+}
+
+/**
+ * Converts an object of type 'KubePriorityLevelConfigurationListV1Beta2Props' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_KubePriorityLevelConfigurationListV1Beta2Props(obj: KubePriorityLevelConfigurationListV1Beta2Props | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'items': obj.items?.map(y => toJson_KubePriorityLevelConfigurationV1Beta2Props(y)),
     'metadata': toJson_ListMeta(obj.metadata),
   };
   // filter undefined values
@@ -12018,326 +11919,6 @@ export function toJson_KubeRoleListProps(obj: KubeRoleListProps | undefined): Re
 /* eslint-enable max-len, quote-props */
 
 /**
- * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRole
- */
-export interface KubeClusterRoleV1Alpha1Props {
-  /**
-   * AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRole#aggregationRule
-   */
-  readonly aggregationRule?: AggregationRuleV1Alpha1;
-
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRole#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * Rules holds all the PolicyRules for this ClusterRole
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRole#rules
-   */
-  readonly rules?: PolicyRuleV1Alpha1[];
-
-}
-
-/**
- * Converts an object of type 'KubeClusterRoleV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeClusterRoleV1Alpha1Props(obj: KubeClusterRoleV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'aggregationRule': toJson_AggregationRuleV1Alpha1(obj.aggregationRule),
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'rules': obj.rules?.map(y => toJson_PolicyRuleV1Alpha1(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBinding
- */
-export interface KubeClusterRoleBindingV1Alpha1Props {
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBinding#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBinding#roleRef
-   */
-  readonly roleRef: RoleRefV1Alpha1;
-
-  /**
-   * Subjects holds references to the objects the role applies to.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBinding#subjects
-   */
-  readonly subjects?: SubjectV1Alpha1[];
-
-}
-
-/**
- * Converts an object of type 'KubeClusterRoleBindingV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeClusterRoleBindingV1Alpha1Props(obj: KubeClusterRoleBindingV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'roleRef': toJson_RoleRefV1Alpha1(obj.roleRef),
-    'subjects': obj.subjects?.map(y => toJson_SubjectV1Alpha1(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindings, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList
- */
-export interface KubeClusterRoleBindingListV1Alpha1Props {
-  /**
-   * Items is a list of ClusterRoleBindings
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList#items
-   */
-  readonly items: KubeClusterRoleBindingV1Alpha1Props[];
-
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubeClusterRoleBindingListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeClusterRoleBindingListV1Alpha1Props(obj: KubeClusterRoleBindingListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubeClusterRoleBindingV1Alpha1Props(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleList
- */
-export interface KubeClusterRoleListV1Alpha1Props {
-  /**
-   * Items is a list of ClusterRoles
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleList#items
-   */
-  readonly items: KubeClusterRoleV1Alpha1Props[];
-
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.ClusterRoleList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubeClusterRoleListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeClusterRoleListV1Alpha1Props(obj: KubeClusterRoleListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubeClusterRoleV1Alpha1Props(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.Role
- */
-export interface KubeRoleV1Alpha1Props {
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.Role#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * Rules holds all the PolicyRules for this Role
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.Role#rules
-   */
-  readonly rules?: PolicyRuleV1Alpha1[];
-
-}
-
-/**
- * Converts an object of type 'KubeRoleV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeRoleV1Alpha1Props(obj: KubeRoleV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'rules': obj.rules?.map(y => toJson_PolicyRuleV1Alpha1(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleBinding
- */
-export interface KubeRoleBindingV1Alpha1Props {
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleBinding#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleBinding#roleRef
-   */
-  readonly roleRef: RoleRefV1Alpha1;
-
-  /**
-   * Subjects holds references to the objects the role applies to.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleBinding#subjects
-   */
-  readonly subjects?: SubjectV1Alpha1[];
-
-}
-
-/**
- * Converts an object of type 'KubeRoleBindingV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeRoleBindingV1Alpha1Props(obj: KubeRoleBindingV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'roleRef': toJson_RoleRefV1Alpha1(obj.roleRef),
-    'subjects': obj.subjects?.map(y => toJson_SubjectV1Alpha1(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleBindingList
- */
-export interface KubeRoleBindingListV1Alpha1Props {
-  /**
-   * Items is a list of RoleBindings
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleBindingList#items
-   */
-  readonly items: KubeRoleBindingV1Alpha1Props[];
-
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleBindingList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubeRoleBindingListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeRoleBindingListV1Alpha1Props(obj: KubeRoleBindingListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubeRoleBindingV1Alpha1Props(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * RoleList is a collection of Roles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.22.
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleList
- */
-export interface KubeRoleListV1Alpha1Props {
-  /**
-   * Items is a list of Roles
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleList#items
-   */
-  readonly items: KubeRoleV1Alpha1Props[];
-
-  /**
-   * Standard object's metadata.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubeRoleListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeRoleListV1Alpha1Props(obj: KubeRoleListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubeRoleV1Alpha1Props(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
  * PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
  *
  * @schema io.k8s.api.scheduling.v1.PriorityClass
@@ -12429,105 +12010,6 @@ export function toJson_KubePriorityClassListProps(obj: KubePriorityClassListProp
   if (obj === undefined) { return undefined; }
   const result = {
     'items': obj.items?.map(y => toJson_KubePriorityClassProps(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
- *
- * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass
- */
-export interface KubePriorityClassV1Alpha1Props {
-  /**
-   * description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass#description
-   */
-  readonly description?: string;
-
-  /**
-   * globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass#globalDefault
-   */
-  readonly globalDefault?: boolean;
-
-  /**
-   * Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
-   *
-   * @default PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass#preemptionPolicy
-   */
-  readonly preemptionPolicy?: string;
-
-  /**
-   * The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClass#value
-   */
-  readonly value: number;
-
-}
-
-/**
- * Converts an object of type 'KubePriorityClassV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubePriorityClassV1Alpha1Props(obj: KubePriorityClassV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'description': obj.description,
-    'globalDefault': obj.globalDefault,
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'preemptionPolicy': obj.preemptionPolicy,
-    'value': obj.value,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * PriorityClassList is a collection of priority classes.
- *
- * @schema io.k8s.api.scheduling.v1alpha1.PriorityClassList
- */
-export interface KubePriorityClassListV1Alpha1Props {
-  /**
-   * items is the list of PriorityClasses
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClassList#items
-   */
-  readonly items: KubePriorityClassV1Alpha1Props[];
-
-  /**
-   * Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   *
-   * @schema io.k8s.api.scheduling.v1alpha1.PriorityClassList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubePriorityClassListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubePriorityClassListV1Alpha1Props(obj: KubePriorityClassListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubePriorityClassV1Alpha1Props(y)),
     'metadata': toJson_ListMeta(obj.metadata),
   };
   // filter undefined values
@@ -12991,82 +12473,6 @@ export function toJson_KubeCsiStorageCapacityListV1Alpha1Props(obj: KubeCsiStora
   if (obj === undefined) { return undefined; }
   const result = {
     'items': obj.items?.map(y => toJson_KubeCsiStorageCapacityV1Alpha1Props(y)),
-    'metadata': toJson_ListMeta(obj.metadata),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
- *
- * VolumeAttachment objects are non-namespaced.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachment
- */
-export interface KubeVolumeAttachmentV1Alpha1Props {
-  /**
-   * Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachment#metadata
-   */
-  readonly metadata?: ObjectMeta;
-
-  /**
-   * Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachment#spec
-   */
-  readonly spec: VolumeAttachmentSpecV1Alpha1;
-
-}
-
-/**
- * Converts an object of type 'KubeVolumeAttachmentV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeVolumeAttachmentV1Alpha1Props(obj: KubeVolumeAttachmentV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'metadata': toJson_ObjectMeta(obj.metadata),
-    'spec': toJson_VolumeAttachmentSpecV1Alpha1(obj.spec),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * VolumeAttachmentList is a collection of VolumeAttachment objects.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentList
- */
-export interface KubeVolumeAttachmentListV1Alpha1Props {
-  /**
-   * Items is the list of VolumeAttachments
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentList#items
-   */
-  readonly items: KubeVolumeAttachmentV1Alpha1Props[];
-
-  /**
-   * Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentList#metadata
-   */
-  readonly metadata?: ListMeta;
-
-}
-
-/**
- * Converts an object of type 'KubeVolumeAttachmentListV1Alpha1Props' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_KubeVolumeAttachmentListV1Alpha1Props(obj: KubeVolumeAttachmentListV1Alpha1Props | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'items': obj.items?.map(y => toJson_KubeVolumeAttachmentV1Alpha1Props(y)),
     'metadata': toJson_ListMeta(obj.metadata),
   };
   // filter undefined values
@@ -14138,11 +13544,22 @@ export interface StatefulSetSpec {
   readonly minReadySeconds?: number;
 
   /**
+   * persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.  +optional
+   *
+   * @schema io.k8s.api.apps.v1.StatefulSetSpec#persistentVolumeClaimRetentionPolicy
+   */
+  readonly persistentVolumeClaimRetentionPolicy?: StatefulSetPersistentVolumeClaimRetentionPolicy;
+
+  /**
    * podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+   *
+   * Possible enum values:
+   * - `"OrderedReady"` will create pods in strictly increasing order on scale up and strictly decreasing order on scale down, progressing only when the previous pod is ready or terminated. At most one pod will be changed at any time.
+   * - `"Parallel"` will create and delete pods as soon as the stateful set replica count is changed, and will not wait for pods to be ready or complete termination.
    *
    * @schema io.k8s.api.apps.v1.StatefulSetSpec#podManagementPolicy
    */
-  readonly podManagementPolicy?: string;
+  readonly podManagementPolicy?: IoK8SApiAppsV1StatefulSetSpecPodManagementPolicy;
 
   /**
    * replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
@@ -14203,6 +13620,7 @@ export function toJson_StatefulSetSpec(obj: StatefulSetSpec | undefined): Record
   if (obj === undefined) { return undefined; }
   const result = {
     'minReadySeconds': obj.minReadySeconds,
+    'persistentVolumeClaimRetentionPolicy': toJson_StatefulSetPersistentVolumeClaimRetentionPolicy(obj.persistentVolumeClaimRetentionPolicy),
     'podManagementPolicy': obj.podManagementPolicy,
     'replicas': obj.replicas,
     'revisionHistoryLimit': obj.revisionHistoryLimit,
@@ -14519,6 +13937,67 @@ export function toJson_ScaleSpec(obj: ScaleSpec | undefined): Record<string, any
 /**
  * HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
  *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec
+ */
+export interface HorizontalPodAutoscalerSpecV2 {
+  /**
+   * behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec#behavior
+   */
+  readonly behavior?: HorizontalPodAutoscalerBehaviorV2;
+
+  /**
+   * maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec#maxReplicas
+   */
+  readonly maxReplicas: number;
+
+  /**
+   * metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec#metrics
+   */
+  readonly metrics?: MetricSpecV2[];
+
+  /**
+   * minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec#minReplicas
+   */
+  readonly minReplicas?: number;
+
+  /**
+   * scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec#scaleTargetRef
+   */
+  readonly scaleTargetRef: CrossVersionObjectReferenceV2;
+
+}
+
+/**
+ * Converts an object of type 'HorizontalPodAutoscalerSpecV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_HorizontalPodAutoscalerSpecV2(obj: HorizontalPodAutoscalerSpecV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'behavior': toJson_HorizontalPodAutoscalerBehaviorV2(obj.behavior),
+    'maxReplicas': obj.maxReplicas,
+    'metrics': obj.metrics?.map(y => toJson_MetricSpecV2(y)),
+    'minReplicas': obj.minReplicas,
+    'scaleTargetRef': toJson_CrossVersionObjectReferenceV2(obj.scaleTargetRef),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+ *
  * @schema io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec
  */
 export interface HorizontalPodAutoscalerSpecV2Beta1 {
@@ -14639,9 +14118,14 @@ export interface CronJobSpec {
   /**
    * Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
    *
+   * Possible enum values:
+   * - `"Allow"` allows CronJobs to run concurrently.
+   * - `"Forbid"` forbids concurrent runs, skipping next run if previous hasn't finished yet.
+   * - `"Replace"` cancels currently running job and replaces it with a new one.
+   *
    * @schema io.k8s.api.batch.v1.CronJobSpec#concurrencyPolicy
    */
-  readonly concurrencyPolicy?: string;
+  readonly concurrencyPolicy?: IoK8SApiBatchV1CronJobSpecConcurrencyPolicy;
 
   /**
    * The number of failed finished jobs to retain. Value must be non-negative integer. Defaults to 1.
@@ -14790,7 +14274,7 @@ export interface JobSpec {
   readonly template: PodTemplateSpec;
 
   /**
-   * ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes. This field is alpha-level and is only honored by servers that enable the TTLAfterFinished feature.
+   * ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
    *
    * @schema io.k8s.api.batch.v1.JobSpec#ttlSecondsAfterFinished
    */
@@ -15633,9 +15117,14 @@ export interface PersistentVolumeSpec {
   /**
    * What happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
    *
+   * Possible enum values:
+   * - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+   * - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+   * - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+   *
    * @schema io.k8s.api.core.v1.PersistentVolumeSpec#persistentVolumeReclaimPolicy
    */
-  readonly persistentVolumeReclaimPolicy?: string;
+  readonly persistentVolumeReclaimPolicy?: IoK8SApiCoreV1PersistentVolumeSpecPersistentVolumeReclaimPolicy;
 
   /**
    * PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
@@ -15778,7 +15267,7 @@ export interface PersistentVolumeClaimSpec {
   readonly dataSourceRef?: TypedLocalObjectReference;
 
   /**
-   * Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+   * Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
    *
    * @schema io.k8s.api.core.v1.PersistentVolumeClaimSpec#resources
    */
@@ -15879,10 +15368,16 @@ export interface PodSpec {
   /**
    * Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
    *
+   * Possible enum values:
+   * - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+   * - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+   * - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+   * - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+   *
    * @default ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
    * @schema io.k8s.api.core.v1.PodSpec#dnsPolicy
    */
-  readonly dnsPolicy?: string;
+  readonly dnsPolicy?: IoK8SApiCoreV1PodSpecDnsPolicy;
 
   /**
    * EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.
@@ -15893,7 +15388,7 @@ export interface PodSpec {
   readonly enableServiceLinks?: boolean;
 
   /**
-   * List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+   * List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.
    *
    * @schema io.k8s.api.core.v1.PodSpec#ephemeralContainers
    */
@@ -15966,6 +15461,17 @@ export interface PodSpec {
   readonly nodeSelector?: { [key: string]: string };
 
   /**
+   * Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+   *
+   * If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+   *
+   * If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature
+   *
+   * @schema io.k8s.api.core.v1.PodSpec#os
+   */
+  readonly os?: PodOs;
+
+  /**
    * Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.
    *
    * @schema io.k8s.api.core.v1.PodSpec#overhead
@@ -16004,10 +15510,15 @@ export interface PodSpec {
   /**
    * Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
    *
+   * Possible enum values:
+   * - `"Always"`
+   * - `"Never"`
+   * - `"OnFailure"`
+   *
    * @default Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
    * @schema io.k8s.api.core.v1.PodSpec#restartPolicy
    */
-  readonly restartPolicy?: string;
+  readonly restartPolicy?: IoK8SApiCoreV1PodSpecRestartPolicy;
 
   /**
    * RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.
@@ -16123,6 +15634,7 @@ export function toJson_PodSpec(obj: PodSpec | undefined): Record<string, any> | 
     'initContainers': obj.initContainers?.map(y => toJson_Container(y)),
     'nodeName': obj.nodeName,
     'nodeSelector': ((obj.nodeSelector) === undefined) ? undefined : (Object.entries(obj.nodeSelector).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {})),
+    'os': toJson_PodOs(obj.os),
     'overhead': ((obj.overhead) === undefined) ? undefined : (Object.entries(obj.overhead).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1]?.value }), {})),
     'preemptionPolicy': obj.preemptionPolicy,
     'priority': obj.priority,
@@ -16308,7 +15820,7 @@ export interface ServiceSpec {
   /**
    * ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
    *
-   * Unless the "IPv6DualStack" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+   * This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    *
    * @schema io.k8s.api.core.v1.ServiceSpec#clusterIPs
    */
@@ -16331,9 +15843,13 @@ export interface ServiceSpec {
   /**
    * externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
    *
+   * Possible enum values:
+   * - `"Cluster"` specifies node-global (legacy) behavior.
+   * - `"Local"` specifies node-local endpoints behavior.
+   *
    * @schema io.k8s.api.core.v1.ServiceSpec#externalTrafficPolicy
    */
-  readonly externalTrafficPolicy?: string;
+  readonly externalTrafficPolicy?: IoK8SApiCoreV1ServiceSpecExternalTrafficPolicy;
 
   /**
    * healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
@@ -16350,7 +15866,7 @@ export interface ServiceSpec {
   readonly internalTrafficPolicy?: string;
 
   /**
-   * IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the "IPv6DualStack" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services.  This field will be wiped when updating a Service to type ExternalName.
+   * IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
    *
    * This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
    *
@@ -16359,7 +15875,7 @@ export interface ServiceSpec {
   readonly ipFamilies?: string[];
 
   /**
-   * IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+   * IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
    *
    * @schema io.k8s.api.core.v1.ServiceSpec#ipFamilyPolicy
    */
@@ -16410,10 +15926,14 @@ export interface ServiceSpec {
   /**
    * Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    *
+   * Possible enum values:
+   * - `"ClientIP"` is the Client IP based.
+   * - `"None"` - no session affinity.
+   *
    * @default None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    * @schema io.k8s.api.core.v1.ServiceSpec#sessionAffinity
    */
-  readonly sessionAffinity?: string;
+  readonly sessionAffinity?: IoK8SApiCoreV1ServiceSpecSessionAffinity;
 
   /**
    * sessionAffinityConfig contains the configurations of session affinity.
@@ -16425,10 +15945,16 @@ export interface ServiceSpec {
   /**
    * type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
    *
+   * Possible enum values:
+   * - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+   * - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+   * - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+   * - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+   *
    * @default ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
    * @schema io.k8s.api.core.v1.ServiceSpec#type
    */
-  readonly type?: string;
+  readonly type?: IoK8SApiCoreV1ServiceSpecType;
 
 }
 
@@ -16492,6 +16018,25 @@ export function toJson_LocalObjectReference(obj: LocalObjectReference | undefine
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+ *
+ * Possible enum values:
+ * - `"FQDN"` represents a FQDN.
+ * - `"IPv4"` represents an IPv4 Address.
+ * - `"IPv6"` represents an IPv6 Address.
+ *
+ * @schema IoK8SApiDiscoveryV1EndpointSliceAddressType
+ */
+export enum IoK8SApiDiscoveryV1EndpointSliceAddressType {
+  /** FQDN */
+  FQDN = 'FQDN',
+  /** IPv4 */
+  I_PV4 = 'IPv4',
+  /** IPv6 */
+  I_PV6 = 'IPv6',
+}
 
 /**
  * Endpoint represents a single logical "backend" implementing a service.
@@ -16608,10 +16153,15 @@ export interface EndpointPort {
   /**
    * The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
    *
+   * Possible enum values:
+   * - `"SCTP"` is the SCTP protocol.
+   * - `"TCP"` is the TCP protocol.
+   * - `"UDP"` is the UDP protocol.
+   *
    * @default TCP.
    * @schema io.k8s.api.core.v1.EndpointPort#protocol
    */
-  readonly protocol?: string;
+  readonly protocol?: IoK8SApiCoreV1EndpointPortProtocol;
 
 }
 
@@ -16891,6 +16441,96 @@ export function toJson_PriorityLevelConfigurationSpecV1Beta1(obj: PriorityLevelC
   if (obj === undefined) { return undefined; }
   const result = {
     'limited': toJson_LimitedPriorityLevelConfigurationV1Beta1(obj.limited),
+    'type': obj.type,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * FlowSchemaSpec describes how the FlowSchema's specification looks like.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec
+ */
+export interface FlowSchemaSpecV1Beta2 {
+  /**
+   * `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec#distinguisherMethod
+   */
+  readonly distinguisherMethod?: FlowDistinguisherMethodV1Beta2;
+
+  /**
+   * `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec#matchingPrecedence
+   */
+  readonly matchingPrecedence?: number;
+
+  /**
+   * `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec#priorityLevelConfiguration
+   */
+  readonly priorityLevelConfiguration: PriorityLevelConfigurationReferenceV1Beta2;
+
+  /**
+   * `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowSchemaSpec#rules
+   */
+  readonly rules?: PolicyRulesWithSubjectsV1Beta2[];
+
+}
+
+/**
+ * Converts an object of type 'FlowSchemaSpecV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_FlowSchemaSpecV1Beta2(obj: FlowSchemaSpecV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'distinguisherMethod': toJson_FlowDistinguisherMethodV1Beta2(obj.distinguisherMethod),
+    'matchingPrecedence': obj.matchingPrecedence,
+    'priorityLevelConfiguration': toJson_PriorityLevelConfigurationReferenceV1Beta2(obj.priorityLevelConfiguration),
+    'rules': obj.rules?.map(y => toJson_PolicyRulesWithSubjectsV1Beta2(y)),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec
+ */
+export interface PriorityLevelConfigurationSpecV1Beta2 {
+  /**
+   * `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec#limited
+   */
+  readonly limited?: LimitedPriorityLevelConfigurationV1Beta2;
+
+  /**
+   * `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationSpec#type
+   */
+  readonly type: string;
+
+}
+
+/**
+ * Converts an object of type 'PriorityLevelConfigurationSpecV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_PriorityLevelConfigurationSpecV1Beta2(obj: PriorityLevelConfigurationSpecV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'limited': toJson_LimitedPriorityLevelConfigurationV1Beta2(obj.limited),
     'type': obj.type,
   };
   // filter undefined values
@@ -17667,7 +17307,7 @@ export interface PolicyRule {
   readonly resources?: string[];
 
   /**
-   * Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
+   * Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
    *
    * @schema io.k8s.api.rbac.v1.PolicyRule#verbs
    */
@@ -17793,195 +17433,6 @@ export function toJson_Subject(obj: Subject | undefined): Record<string, any> | 
 /* eslint-enable max-len, quote-props */
 
 /**
- * AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
- *
- * @schema io.k8s.api.rbac.v1alpha1.AggregationRule
- */
-export interface AggregationRuleV1Alpha1 {
-  /**
-   * ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.AggregationRule#clusterRoleSelectors
-   */
-  readonly clusterRoleSelectors?: LabelSelector[];
-
-}
-
-/**
- * Converts an object of type 'AggregationRuleV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_AggregationRuleV1Alpha1(obj: AggregationRuleV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'clusterRoleSelectors': obj.clusterRoleSelectors?.map(y => toJson_LabelSelector(y)),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
- *
- * @schema io.k8s.api.rbac.v1alpha1.PolicyRule
- */
-export interface PolicyRuleV1Alpha1 {
-  /**
-   * APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.PolicyRule#apiGroups
-   */
-  readonly apiGroups?: string[];
-
-  /**
-   * NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.PolicyRule#nonResourceURLs
-   */
-  readonly nonResourceUrLs?: string[];
-
-  /**
-   * ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.PolicyRule#resourceNames
-   */
-  readonly resourceNames?: string[];
-
-  /**
-   * Resources is a list of resources this rule applies to. '*' represents all resources.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.PolicyRule#resources
-   */
-  readonly resources?: string[];
-
-  /**
-   * Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. '*' represents all verbs.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.PolicyRule#verbs
-   */
-  readonly verbs: string[];
-
-}
-
-/**
- * Converts an object of type 'PolicyRuleV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_PolicyRuleV1Alpha1(obj: PolicyRuleV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'apiGroups': obj.apiGroups?.map(y => y),
-    'nonResourceURLs': obj.nonResourceUrLs?.map(y => y),
-    'resourceNames': obj.resourceNames?.map(y => y),
-    'resources': obj.resources?.map(y => y),
-    'verbs': obj.verbs?.map(y => y),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * RoleRef contains information that points to the role being used
- *
- * @schema io.k8s.api.rbac.v1alpha1.RoleRef
- */
-export interface RoleRefV1Alpha1 {
-  /**
-   * APIGroup is the group for the resource being referenced
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleRef#apiGroup
-   */
-  readonly apiGroup: string;
-
-  /**
-   * Kind is the type of resource being referenced
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleRef#kind
-   */
-  readonly kind: string;
-
-  /**
-   * Name is the name of resource being referenced
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.RoleRef#name
-   */
-  readonly name: string;
-
-}
-
-/**
- * Converts an object of type 'RoleRefV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_RoleRefV1Alpha1(obj: RoleRefV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'apiGroup': obj.apiGroup,
-    'kind': obj.kind,
-    'name': obj.name,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
- *
- * @schema io.k8s.api.rbac.v1alpha1.Subject
- */
-export interface SubjectV1Alpha1 {
-  /**
-   * APIVersion holds the API group and version of the referenced subject. Defaults to "v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
-   *
-   * @default v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
-   * @schema io.k8s.api.rbac.v1alpha1.Subject#apiVersion
-   */
-  readonly apiVersion?: string;
-
-  /**
-   * Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.Subject#kind
-   */
-  readonly kind: string;
-
-  /**
-   * Name of the object being referenced.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.Subject#name
-   */
-  readonly name: string;
-
-  /**
-   * Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
-   *
-   * @schema io.k8s.api.rbac.v1alpha1.Subject#namespace
-   */
-  readonly namespace?: string;
-
-}
-
-/**
- * Converts an object of type 'SubjectV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_SubjectV1Alpha1(obj: SubjectV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'apiVersion': obj.apiVersion,
-    'kind': obj.kind,
-    'name': obj.name,
-    'namespace': obj.namespace,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
  * CSIDriverSpec is the specification of a CSIDriver.
  *
  * @schema io.k8s.api.storage.v1.CSIDriverSpec
@@ -17997,7 +17448,7 @@ export interface CsiDriverSpec {
   readonly attachRequired?: boolean;
 
   /**
-   * Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details. This field is beta, and is only honored by servers that enable the CSIVolumeFSGroupPolicy feature gate.
+   * Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details.
    *
    * This field is immutable.
    *
@@ -18037,7 +17488,7 @@ export interface CsiDriverSpec {
    *
    * Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
    *
-   * This field is immutable.
+   * This field was immutable in Kubernetes <= 1.22 and now is mutable.
    *
    * This is a beta field and only available when the CSIStorageCapacity feature is enabled. The default is false.
    *
@@ -18239,51 +17690,6 @@ export function toJson_LabelSelector(obj: LabelSelector | undefined): Record<str
   const result = {
     'matchExpressions': obj.matchExpressions?.map(y => toJson_LabelSelectorRequirement(y)),
     'matchLabels': ((obj.matchLabels) === undefined) ? undefined : (Object.entries(obj.matchLabels).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {})),
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
- * VolumeAttachmentSpec is the specification of a VolumeAttachment request.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec
- */
-export interface VolumeAttachmentSpecV1Alpha1 {
-  /**
-   * Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec#attacher
-   */
-  readonly attacher: string;
-
-  /**
-   * The node that the volume should be attached to.
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec#nodeName
-   */
-  readonly nodeName: string;
-
-  /**
-   * Source represents the volume that should be attached.
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec#source
-   */
-  readonly source: VolumeAttachmentSourceV1Alpha1;
-
-}
-
-/**
- * Converts an object of type 'VolumeAttachmentSpecV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_VolumeAttachmentSpecV1Alpha1(obj: VolumeAttachmentSpecV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'attacher': obj.attacher,
-    'nodeName': obj.nodeName,
-    'source': toJson_VolumeAttachmentSourceV1Alpha1(obj.source),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -18793,10 +18199,14 @@ export interface DaemonSetUpdateStrategy {
   /**
    * Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
    *
+   * Possible enum values:
+   * - `"OnDelete"` Replace the old daemons only when it's killed
+   * - `"RollingUpdate"` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+   *
    * @default RollingUpdate.
    * @schema io.k8s.api.apps.v1.DaemonSetUpdateStrategy#type
    */
-  readonly type?: string;
+  readonly type?: IoK8SApiAppsV1DaemonSetUpdateStrategyType;
 
 }
 
@@ -18831,10 +18241,14 @@ export interface DeploymentStrategy {
   /**
    * Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
    *
+   * Possible enum values:
+   * - `"Recreate"` Kill all existing pods before creating new ones.
+   * - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+   *
    * @default RollingUpdate.
    * @schema io.k8s.api.apps.v1.DeploymentStrategy#type
    */
-  readonly type?: string;
+  readonly type?: IoK8SApiAppsV1DeploymentStrategyType;
 
 }
 
@@ -18854,6 +18268,59 @@ export function toJson_DeploymentStrategy(obj: DeploymentStrategy | undefined): 
 /* eslint-enable max-len, quote-props */
 
 /**
+ * StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.
+ *
+ * @schema io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy
+ */
+export interface StatefulSetPersistentVolumeClaimRetentionPolicy {
+  /**
+   * WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
+   *
+   * @schema io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy#whenDeleted
+   */
+  readonly whenDeleted?: string;
+
+  /**
+   * WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
+   *
+   * @schema io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy#whenScaled
+   */
+  readonly whenScaled?: string;
+
+}
+
+/**
+ * Converts an object of type 'StatefulSetPersistentVolumeClaimRetentionPolicy' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_StatefulSetPersistentVolumeClaimRetentionPolicy(obj: StatefulSetPersistentVolumeClaimRetentionPolicy | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'whenDeleted': obj.whenDeleted,
+    'whenScaled': obj.whenScaled,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+ *
+ * Possible enum values:
+ * - `"OrderedReady"` will create pods in strictly increasing order on scale up and strictly decreasing order on scale down, progressing only when the previous pod is ready or terminated. At most one pod will be changed at any time.
+ * - `"Parallel"` will create and delete pods as soon as the stateful set replica count is changed, and will not wait for pods to be ready or complete termination.
+ *
+ * @schema IoK8SApiAppsV1StatefulSetSpecPodManagementPolicy
+ */
+export enum IoK8SApiAppsV1StatefulSetSpecPodManagementPolicy {
+  /** OrderedReady */
+  ORDERED_READY = 'OrderedReady',
+  /** Parallel */
+  PARALLEL = 'Parallel',
+}
+
+/**
  * StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
  *
  * @schema io.k8s.api.apps.v1.StatefulSetUpdateStrategy
@@ -18869,10 +18336,14 @@ export interface StatefulSetUpdateStrategy {
   /**
    * Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
    *
+   * Possible enum values:
+   * - `"OnDelete"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.
+   * - `"RollingUpdate"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.
+   *
    * @default RollingUpdate.
    * @schema io.k8s.api.apps.v1.StatefulSetUpdateStrategy#type
    */
-  readonly type?: string;
+  readonly type?: IoK8SApiAppsV1StatefulSetUpdateStrategyType;
 
 }
 
@@ -19092,6 +18563,160 @@ export interface CrossVersionObjectReference {
  */
 /* eslint-disable max-len, quote-props */
 export function toJson_CrossVersionObjectReference(obj: CrossVersionObjectReference | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'apiVersion': obj.apiVersion,
+    'kind': obj.kind,
+    'name': obj.name,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).
+ *
+ * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior
+ */
+export interface HorizontalPodAutoscalerBehaviorV2 {
+  /**
+   * scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior#scaleDown
+   */
+  readonly scaleDown?: HpaScalingRulesV2;
+
+  /**
+   * scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+   * * increase no more than 4 pods per 60 seconds
+   * * double the number of pods per 60 seconds
+   * No stabilization is used.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior#scaleUp
+   */
+  readonly scaleUp?: HpaScalingRulesV2;
+
+}
+
+/**
+ * Converts an object of type 'HorizontalPodAutoscalerBehaviorV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_HorizontalPodAutoscalerBehaviorV2(obj: HorizontalPodAutoscalerBehaviorV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'scaleDown': toJson_HpaScalingRulesV2(obj.scaleDown),
+    'scaleUp': toJson_HpaScalingRulesV2(obj.scaleUp),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+ *
+ * @schema io.k8s.api.autoscaling.v2.MetricSpec
+ */
+export interface MetricSpecV2 {
+  /**
+   * containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#containerResource
+   */
+  readonly containerResource?: ContainerResourceMetricSourceV2;
+
+  /**
+   * external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#external
+   */
+  readonly external?: ExternalMetricSourceV2;
+
+  /**
+   * object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#object
+   */
+  readonly object?: ObjectMetricSourceV2;
+
+  /**
+   * pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#pods
+   */
+  readonly pods?: PodsMetricSourceV2;
+
+  /**
+   * resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#resource
+   */
+  readonly resource?: ResourceMetricSourceV2;
+
+  /**
+   * type is the type of metric source.  It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricSpec#type
+   */
+  readonly type: string;
+
+}
+
+/**
+ * Converts an object of type 'MetricSpecV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MetricSpecV2(obj: MetricSpecV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'containerResource': toJson_ContainerResourceMetricSourceV2(obj.containerResource),
+    'external': toJson_ExternalMetricSourceV2(obj.external),
+    'object': toJson_ObjectMetricSourceV2(obj.object),
+    'pods': toJson_PodsMetricSourceV2(obj.pods),
+    'resource': toJson_ResourceMetricSourceV2(obj.resource),
+    'type': obj.type,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * CrossVersionObjectReference contains enough information to let you identify the referred resource.
+ *
+ * @schema io.k8s.api.autoscaling.v2.CrossVersionObjectReference
+ */
+export interface CrossVersionObjectReferenceV2 {
+  /**
+   * API version of the referent
+   *
+   * @schema io.k8s.api.autoscaling.v2.CrossVersionObjectReference#apiVersion
+   */
+  readonly apiVersion?: string;
+
+  /**
+   * Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+   *
+   * @schema io.k8s.api.autoscaling.v2.CrossVersionObjectReference#kind
+   */
+  readonly kind: string;
+
+  /**
+   * Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+   *
+   * @schema io.k8s.api.autoscaling.v2.CrossVersionObjectReference#name
+   */
+  readonly name: string;
+
+}
+
+/**
+ * Converts an object of type 'CrossVersionObjectReferenceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_CrossVersionObjectReferenceV2(obj: CrossVersionObjectReferenceV2 | undefined): Record<string, any> | undefined {
   if (obj === undefined) { return undefined; }
   const result = {
     'apiVersion': obj.apiVersion,
@@ -19372,6 +18997,25 @@ export function toJson_CrossVersionObjectReferenceV2Beta2(obj: CrossVersionObjec
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+ *
+ * Possible enum values:
+ * - `"Allow"` allows CronJobs to run concurrently.
+ * - `"Forbid"` forbids concurrent runs, skipping next run if previous hasn't finished yet.
+ * - `"Replace"` cancels currently running job and replaces it with a new one.
+ *
+ * @schema IoK8SApiBatchV1CronJobSpecConcurrencyPolicy
+ */
+export enum IoK8SApiBatchV1CronJobSpecConcurrencyPolicy {
+  /** Allow */
+  ALLOW = 'Allow',
+  /** Forbid */
+  FORBID = 'Forbid',
+  /** Replace */
+  REPLACE = 'Replace',
+}
+
+/**
  * JobTemplateSpec describes the data a Job should have when created from a template
  *
  * @schema io.k8s.api.batch.v1.JobTemplateSpec
@@ -19542,9 +19186,14 @@ export interface LimitRangeItem {
   /**
    * Type of resource that this limit applies to.
    *
+   * Possible enum values:
+   * - `"Container"` Limit that applies to all containers in a namespace
+   * - `"PersistentVolumeClaim"` Limit that applies to all persistent volume claims in a namespace
+   * - `"Pod"` Limit that applies to all pods in a namespace
+   *
    * @schema io.k8s.api.core.v1.LimitRangeItem#type
    */
-  readonly type: string;
+  readonly type: IoK8SApiCoreV1LimitRangeItemType;
 
 }
 
@@ -19605,9 +19254,14 @@ export interface Taint {
   /**
    * Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
    *
+   * Possible enum values:
+   * - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+   * - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+   * - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+   *
    * @schema io.k8s.api.core.v1.Taint#effect
    */
-  readonly effect: string;
+  readonly effect: IoK8SApiCoreV1TaintEffect;
 
   /**
    * Required. The taint key to be applied to a node.
@@ -20473,7 +20127,7 @@ export function toJson_IscsiPersistentVolumeSource(obj: IscsiPersistentVolumeSou
  */
 export interface LocalVolumeSource {
   /**
-   * Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a fileystem if unspecified.
+   * Filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.
    *
    * @schema io.k8s.api.core.v1.LocalVolumeSource#fsType
    */
@@ -20577,6 +20231,25 @@ export function toJson_VolumeNodeAffinity(obj: VolumeNodeAffinity | undefined): 
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * What happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+ *
+ * Possible enum values:
+ * - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+ * - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+ * - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+ *
+ * @schema IoK8SApiCoreV1PersistentVolumeSpecPersistentVolumeReclaimPolicy
+ */
+export enum IoK8SApiCoreV1PersistentVolumeSpecPersistentVolumeReclaimPolicy {
+  /** Delete */
+  DELETE = 'Delete',
+  /** Recycle */
+  RECYCLE = 'Recycle',
+  /** Retain */
+  RETAIN = 'Retain',
+}
 
 /**
  * Represents a Photon Controller persistent disk resource.
@@ -21213,10 +20886,15 @@ export interface Container {
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
    *
+   * Possible enum values:
+   * - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   * - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   * - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+   *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
    * @schema io.k8s.api.core.v1.Container#imagePullPolicy
    */
-  readonly imagePullPolicy?: string;
+  readonly imagePullPolicy?: IoK8SApiCoreV1ContainerImagePullPolicy;
 
   /**
    * Actions that the management system should take in response to container lifecycle events. Cannot be updated.
@@ -21301,10 +20979,14 @@ export interface Container {
   /**
    * Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
    *
+   * Possible enum values:
+   * - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+   * - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+   *
    * @default File. Cannot be updated.
    * @schema io.k8s.api.core.v1.Container#terminationMessagePolicy
    */
-  readonly terminationMessagePolicy?: string;
+  readonly terminationMessagePolicy?: IoK8SApiCoreV1ContainerTerminationMessagePolicy;
 
   /**
    * Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
@@ -21418,7 +21100,34 @@ export function toJson_PodDnsConfig(obj: PodDnsConfig | undefined): Record<strin
 /* eslint-enable max-len, quote-props */
 
 /**
- * An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+ * Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+ *
+ * Possible enum values:
+ * - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+ * - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+ * - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+ * - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+ *
+ * @default ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+ * @schema IoK8SApiCoreV1PodSpecDnsPolicy
+ */
+export enum IoK8SApiCoreV1PodSpecDnsPolicy {
+  /** ClusterFirst */
+  CLUSTER_FIRST = 'ClusterFirst',
+  /** ClusterFirstWithHostNet */
+  CLUSTER_FIRST_WITH_HOST_NET = 'ClusterFirstWithHostNet',
+  /** Default */
+  DEFAULT = 'Default',
+  /** None */
+  NONE = 'None',
+}
+
+/**
+ * An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+ *
+ * To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+ *
+ * This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate.
  *
  * @schema io.k8s.api.core.v1.EphemeralContainer
  */
@@ -21461,10 +21170,15 @@ export interface EphemeralContainer {
   /**
    * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
    *
+   * Possible enum values:
+   * - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+   * - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+   * - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+   *
    * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
    * @schema io.k8s.api.core.v1.EphemeralContainer#imagePullPolicy
    */
-  readonly imagePullPolicy?: string;
+  readonly imagePullPolicy?: IoK8SApiCoreV1EphemeralContainerImagePullPolicy;
 
   /**
    * Lifecycle is not allowed for ephemeral containers.
@@ -21539,7 +21253,9 @@ export interface EphemeralContainer {
   readonly stdinOnce?: boolean;
 
   /**
-   * If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+   * If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+   *
+   * The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
    *
    * @schema io.k8s.api.core.v1.EphemeralContainer#targetContainerName
    */
@@ -21556,10 +21272,14 @@ export interface EphemeralContainer {
   /**
    * Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
    *
+   * Possible enum values:
+   * - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+   * - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+   *
    * @default File. Cannot be updated.
    * @schema io.k8s.api.core.v1.EphemeralContainer#terminationMessagePolicy
    */
-  readonly terminationMessagePolicy?: string;
+  readonly terminationMessagePolicy?: IoK8SApiCoreV1EphemeralContainerTerminationMessagePolicy;
 
   /**
    * Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
@@ -21577,7 +21297,7 @@ export interface EphemeralContainer {
   readonly volumeDevices?: VolumeDevice[];
 
   /**
-   * Pod volumes to mount into the container's filesystem. Cannot be updated.
+   * Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
    *
    * @schema io.k8s.api.core.v1.EphemeralContainer#volumeMounts
    */
@@ -21666,6 +21386,35 @@ export function toJson_HostAlias(obj: HostAlias | undefined): Record<string, any
 /* eslint-enable max-len, quote-props */
 
 /**
+ * PodOS defines the OS parameters of a pod.
+ *
+ * @schema io.k8s.api.core.v1.PodOS
+ */
+export interface PodOs {
+  /**
+   * Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+   *
+   * @schema io.k8s.api.core.v1.PodOS#name
+   */
+  readonly name: string;
+
+}
+
+/**
+ * Converts an object of type 'PodOs' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_PodOs(obj: PodOs | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
  * PodReadinessGate contains the reference to a pod condition
  *
  * @schema io.k8s.api.core.v1.PodReadinessGate
@@ -21674,9 +21423,15 @@ export interface PodReadinessGate {
   /**
    * ConditionType refers to a condition in the pod's condition list with matching type.
    *
+   * Possible enum values:
+   * - `"ContainersReady"` indicates whether all containers in the pod are ready.
+   * - `"Initialized"` means that all init containers in the pod have started successfully.
+   * - `"PodScheduled"` represents status of the scheduling process for this pod.
+   * - `"Ready"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.
+   *
    * @schema io.k8s.api.core.v1.PodReadinessGate#conditionType
    */
-  readonly conditionType: string;
+  readonly conditionType: IoK8SApiCoreV1PodReadinessGateConditionType;
 
 }
 
@@ -21695,6 +21450,26 @@ export function toJson_PodReadinessGate(obj: PodReadinessGate | undefined): Reco
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+ *
+ * Possible enum values:
+ * - `"Always"`
+ * - `"Never"`
+ * - `"OnFailure"`
+ *
+ * @default Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+ * @schema IoK8SApiCoreV1PodSpecRestartPolicy
+ */
+export enum IoK8SApiCoreV1PodSpecRestartPolicy {
+  /** Always */
+  ALWAYS = 'Always',
+  /** Never */
+  NEVER = 'Never',
+  /** OnFailure */
+  ON_FAILURE = 'OnFailure',
+}
+
+/**
  * PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
  *
  * @schema io.k8s.api.core.v1.PodSecurityContext
@@ -21705,21 +21480,21 @@ export interface PodSecurityContext {
    *
    * 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
    *
-   * If unset, the Kubelet will not modify the ownership and permissions of any volume.
+   * If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#fsGroup
    */
   readonly fsGroup?: number;
 
   /**
-   * fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+   * fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#fsGroupChangePolicy
    */
   readonly fsGroupChangePolicy?: string;
 
   /**
-   * The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+   * The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#runAsGroup
    */
@@ -21733,43 +21508,43 @@ export interface PodSecurityContext {
   readonly runAsNonRoot?: boolean;
 
   /**
-   * The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+   * The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
    *
-   * @default user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+   * @default user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
    * @schema io.k8s.api.core.v1.PodSecurityContext#runAsUser
    */
   readonly runAsUser?: number;
 
   /**
-   * The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+   * The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#seLinuxOptions
    */
   readonly seLinuxOptions?: SeLinuxOptions;
 
   /**
-   * The seccomp options to use by the containers in this pod.
+   * The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#seccompProfile
    */
   readonly seccompProfile?: SeccompProfile;
 
   /**
-   * A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+   * A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#supplementalGroups
    */
   readonly supplementalGroups?: number[];
 
   /**
-   * Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+   * Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#sysctls
    */
   readonly sysctls?: Sysctl[];
 
   /**
-   * The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
    *
    * @schema io.k8s.api.core.v1.PodSecurityContext#windowsOptions
    */
@@ -21809,9 +21584,14 @@ export interface Toleration {
   /**
    * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
    *
+   * Possible enum values:
+   * - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+   * - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+   * - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+   *
    * @schema io.k8s.api.core.v1.Toleration#effect
    */
-  readonly effect?: string;
+  readonly effect?: IoK8SApiCoreV1TolerationEffect;
 
   /**
    * Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
@@ -21823,10 +21603,14 @@ export interface Toleration {
   /**
    * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
    *
+   * Possible enum values:
+   * - `"Equal"`
+   * - `"Exists"`
+   *
    * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
    * @schema io.k8s.api.core.v1.Toleration#operator
    */
-  readonly operator?: string;
+  readonly operator?: IoK8SApiCoreV1TolerationOperator;
 
   /**
    * TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
@@ -21893,11 +21677,15 @@ export interface TopologySpreadConstraint {
    * WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
    * but giving higher precedence to topologies that would help reduce the
    * skew.
-   * A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+   * A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+   *
+   * Possible enum values:
+   * - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+   * - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
    *
    * @schema io.k8s.api.core.v1.TopologySpreadConstraint#whenUnsatisfiable
    */
-  readonly whenUnsatisfiable: string;
+  readonly whenUnsatisfiable: IoK8SApiCoreV1TopologySpreadConstraintWhenUnsatisfiable;
 
 }
 
@@ -22002,8 +21790,6 @@ export interface Volume {
    * Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
    *
    * A pod can use both types of ephemeral volumes and persistent volumes at the same time.
-   *
-   * This is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled.
    *
    * @schema io.k8s.api.core.v1.Volume#ephemeral
    */
@@ -22224,6 +22010,22 @@ export function toJson_ScopeSelector(obj: ScopeSelector | undefined): Record<str
 /* eslint-enable max-len, quote-props */
 
 /**
+ * externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+ *
+ * Possible enum values:
+ * - `"Cluster"` specifies node-global (legacy) behavior.
+ * - `"Local"` specifies node-local endpoints behavior.
+ *
+ * @schema IoK8SApiCoreV1ServiceSpecExternalTrafficPolicy
+ */
+export enum IoK8SApiCoreV1ServiceSpecExternalTrafficPolicy {
+  /** Cluster */
+  CLUSTER = 'Cluster',
+  /** Local */
+  LOCAL = 'Local',
+}
+
+/**
  * ServicePort contains information on service's port.
  *
  * @schema io.k8s.api.core.v1.ServicePort
@@ -22260,10 +22062,15 @@ export interface ServicePort {
   /**
    * The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
    *
+   * Possible enum values:
+   * - `"SCTP"` is the SCTP protocol.
+   * - `"TCP"` is the TCP protocol.
+   * - `"UDP"` is the UDP protocol.
+   *
    * @default TCP.
    * @schema io.k8s.api.core.v1.ServicePort#protocol
    */
-  readonly protocol?: string;
+  readonly protocol?: IoK8SApiCoreV1ServicePortProtocol;
 
   /**
    * Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
@@ -22294,6 +22101,23 @@ export function toJson_ServicePort(obj: ServicePort | undefined): Record<string,
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+ *
+ * Possible enum values:
+ * - `"ClientIP"` is the Client IP based.
+ * - `"None"` - no session affinity.
+ *
+ * @default None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+ * @schema IoK8SApiCoreV1ServiceSpecSessionAffinity
+ */
+export enum IoK8SApiCoreV1ServiceSpecSessionAffinity {
+  /** ClientIP */
+  CLIENT_IP = 'ClientIP',
+  /** None */
+  NONE = 'None',
+}
+
+/**
  * SessionAffinityConfig represents the configurations of session affinity.
  *
  * @schema io.k8s.api.core.v1.SessionAffinityConfig
@@ -22321,6 +22145,29 @@ export function toJson_SessionAffinityConfig(obj: SessionAffinityConfig | undefi
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+ *
+ * Possible enum values:
+ * - `"ClusterIP"` means a service will only be accessible inside the cluster, via the cluster IP.
+ * - `"ExternalName"` means a service consists of only a reference to an external name that kubedns or equivalent will return as a CNAME record, with no exposing or proxying of any pods involved.
+ * - `"LoadBalancer"` means a service will be exposed via an external load balancer (if the cloud provider supports it), in addition to 'NodePort' type.
+ * - `"NodePort"` means a service will be exposed on one port of every node, in addition to 'ClusterIP' type.
+ *
+ * @default ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+ * @schema IoK8SApiCoreV1ServiceSpecType
+ */
+export enum IoK8SApiCoreV1ServiceSpecType {
+  /** ClusterIP */
+  CLUSTER_IP = 'ClusterIP',
+  /** ExternalName */
+  EXTERNAL_NAME = 'ExternalName',
+  /** LoadBalancer */
+  LOAD_BALANCER = 'LoadBalancer',
+  /** NodePort */
+  NODE_PORT = 'NodePort',
+}
 
 /**
  * EndpointConditions represents the current condition of an endpoint.
@@ -22395,6 +22242,26 @@ export function toJson_EndpointHints(obj: EndpointHints | undefined): Record<str
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+ *
+ * Possible enum values:
+ * - `"SCTP"` is the SCTP protocol.
+ * - `"TCP"` is the TCP protocol.
+ * - `"UDP"` is the UDP protocol.
+ *
+ * @default TCP.
+ * @schema IoK8SApiCoreV1EndpointPortProtocol
+ */
+export enum IoK8SApiCoreV1EndpointPortProtocol {
+  /** SCTP */
+  SCTP = 'SCTP',
+  /** TCP */
+  TCP = 'TCP',
+  /** UDP */
+  UDP = 'UDP',
+}
 
 /**
  * EndpointConditions represents the current condition of an endpoint.
@@ -22617,6 +22484,152 @@ export function toJson_LimitedPriorityLevelConfigurationV1Beta1(obj: LimitedPrio
 /* eslint-enable max-len, quote-props */
 
 /**
+ * FlowDistinguisherMethod specifies the method of a flow distinguisher.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod
+ */
+export interface FlowDistinguisherMethodV1Beta2 {
+  /**
+   * `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.FlowDistinguisherMethod#type
+   */
+  readonly type: string;
+
+}
+
+/**
+ * Converts an object of type 'FlowDistinguisherMethodV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_FlowDistinguisherMethodV1Beta2(obj: FlowDistinguisherMethodV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'type': obj.type,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference
+ */
+export interface PriorityLevelConfigurationReferenceV1Beta2 {
+  /**
+   * `name` is the name of the priority level configuration being referenced Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationReference#name
+   */
+  readonly name: string;
+
+}
+
+/**
+ * Converts an object of type 'PriorityLevelConfigurationReferenceV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_PriorityLevelConfigurationReferenceV1Beta2(obj: PriorityLevelConfigurationReferenceV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects
+ */
+export interface PolicyRulesWithSubjectsV1Beta2 {
+  /**
+   * `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects#nonResourceRules
+   */
+  readonly nonResourceRules?: NonResourcePolicyRuleV1Beta2[];
+
+  /**
+   * `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects#resourceRules
+   */
+  readonly resourceRules?: ResourcePolicyRuleV1Beta2[];
+
+  /**
+   * subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.PolicyRulesWithSubjects#subjects
+   */
+  readonly subjects: SubjectV1Beta2[];
+
+}
+
+/**
+ * Converts an object of type 'PolicyRulesWithSubjectsV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_PolicyRulesWithSubjectsV1Beta2(obj: PolicyRulesWithSubjectsV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'nonResourceRules': obj.nonResourceRules?.map(y => toJson_NonResourcePolicyRuleV1Beta2(y)),
+    'resourceRules': obj.resourceRules?.map(y => toJson_ResourcePolicyRuleV1Beta2(y)),
+    'subjects': obj.subjects?.map(y => toJson_SubjectV1Beta2(y)),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+ * * How are requests for this priority level limited?
+ * * What should be done with requests that exceed the limit?
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration
+ */
+export interface LimitedPriorityLevelConfigurationV1Beta2 {
+  /**
+   * `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+   *
+   * ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+   *
+   * bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration#assuredConcurrencyShares
+   */
+  readonly assuredConcurrencyShares?: number;
+
+  /**
+   * `limitResponse` indicates what to do with requests that can not be executed right now
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.LimitedPriorityLevelConfiguration#limitResponse
+   */
+  readonly limitResponse?: LimitResponseV1Beta2;
+
+}
+
+/**
+ * Converts an object of type 'LimitedPriorityLevelConfigurationV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_LimitedPriorityLevelConfigurationV1Beta2(obj: LimitedPriorityLevelConfigurationV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'assuredConcurrencyShares': obj.assuredConcurrencyShares,
+    'limitResponse': toJson_LimitResponseV1Beta2(obj.limitResponse),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
  * IngressBackend describes all endpoints for a given service and port.
  *
  * @schema io.k8s.api.networking.v1.IngressBackend
@@ -22768,7 +22781,7 @@ export interface IngressClassParametersReference {
   readonly namespace?: string;
 
   /**
-   * Scope represents if this refers to a cluster or namespace scoped resource. This may be set to "Cluster" (default) or "Namespace". Field can be enabled with IngressClassNamespacedParams feature gate.
+   * Scope represents if this refers to a cluster or namespace scoped resource. This may be set to "Cluster" (default) or "Namespace".
    *
    * @schema io.k8s.api.networking.v1.IngressClassParametersReference#scope
    */
@@ -23561,43 +23574,6 @@ export function toJson_LabelSelectorRequirement(obj: LabelSelectorRequirement | 
 /* eslint-enable max-len, quote-props */
 
 /**
- * VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
- *
- * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSource
- */
-export interface VolumeAttachmentSourceV1Alpha1 {
-  /**
-   * inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSource#inlineVolumeSpec
-   */
-  readonly inlineVolumeSpec?: PersistentVolumeSpec;
-
-  /**
-   * Name of the persistent volume to attach.
-   *
-   * @schema io.k8s.api.storage.v1alpha1.VolumeAttachmentSource#persistentVolumeName
-   */
-  readonly persistentVolumeName?: string;
-
-}
-
-/**
- * Converts an object of type 'VolumeAttachmentSourceV1Alpha1' to JSON representation.
- */
-/* eslint-disable max-len, quote-props */
-export function toJson_VolumeAttachmentSourceV1Alpha1(obj: VolumeAttachmentSourceV1Alpha1 | undefined): Record<string, any> | undefined {
-  if (obj === undefined) { return undefined; }
-  const result = {
-    'inlineVolumeSpec': toJson_PersistentVolumeSpec(obj.inlineVolumeSpec),
-    'persistentVolumeName': obj.persistentVolumeName,
-  };
-  // filter undefined values
-  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
-}
-/* eslint-enable max-len, quote-props */
-
-/**
  * CustomResourceConversion describes how to convert different versions of a CR.
  *
  * @schema io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion
@@ -23933,6 +23909,23 @@ export function toJson_RollingUpdateDaemonSet(obj: RollingUpdateDaemonSet | unde
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+ *
+ * Possible enum values:
+ * - `"OnDelete"` Replace the old daemons only when it's killed
+ * - `"RollingUpdate"` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+ *
+ * @default RollingUpdate.
+ * @schema IoK8SApiAppsV1DaemonSetUpdateStrategyType
+ */
+export enum IoK8SApiAppsV1DaemonSetUpdateStrategyType {
+  /** OnDelete */
+  ON_DELETE = 'OnDelete',
+  /** RollingUpdate */
+  ROLLING_UPDATE = 'RollingUpdate',
+}
+
+/**
  * Spec to control the desired behavior of rolling update.
  *
  * @schema io.k8s.api.apps.v1.RollingUpdateDeployment
@@ -23972,6 +23965,23 @@ export function toJson_RollingUpdateDeployment(obj: RollingUpdateDeployment | un
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+ *
+ * Possible enum values:
+ * - `"Recreate"` Kill all existing pods before creating new ones.
+ * - `"RollingUpdate"` Replace the old ReplicaSets by new one using rolling update i.e gradually scale down the old ReplicaSets and scale up the new one.
+ *
+ * @default RollingUpdate.
+ * @schema IoK8SApiAppsV1DeploymentStrategyType
+ */
+export enum IoK8SApiAppsV1DeploymentStrategyType {
+  /** Recreate */
+  RECREATE = 'Recreate',
+  /** RollingUpdate */
+  ROLLING_UPDATE = 'RollingUpdate',
+}
+
+/**
  * RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
  *
  * @schema io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy
@@ -23994,6 +24004,269 @@ export function toJson_RollingUpdateStatefulSetStrategy(obj: RollingUpdateStatef
   if (obj === undefined) { return undefined; }
   const result = {
     'partition': obj.partition,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+ *
+ * Possible enum values:
+ * - `"OnDelete"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.
+ * - `"RollingUpdate"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.
+ *
+ * @default RollingUpdate.
+ * @schema IoK8SApiAppsV1StatefulSetUpdateStrategyType
+ */
+export enum IoK8SApiAppsV1StatefulSetUpdateStrategyType {
+  /** OnDelete */
+  ON_DELETE = 'OnDelete',
+  /** RollingUpdate */
+  ROLLING_UPDATE = 'RollingUpdate',
+}
+
+/**
+ * HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.
+ *
+ * @schema io.k8s.api.autoscaling.v2.HPAScalingRules
+ */
+export interface HpaScalingRulesV2 {
+  /**
+   * policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingRules#policies
+   */
+  readonly policies?: HpaScalingPolicyV2[];
+
+  /**
+   * selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingRules#selectPolicy
+   */
+  readonly selectPolicy?: string;
+
+  /**
+   * StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingRules#stabilizationWindowSeconds
+   */
+  readonly stabilizationWindowSeconds?: number;
+
+}
+
+/**
+ * Converts an object of type 'HpaScalingRulesV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_HpaScalingRulesV2(obj: HpaScalingRulesV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'policies': obj.policies?.map(y => toJson_HpaScalingPolicyV2(y)),
+    'selectPolicy': obj.selectPolicy,
+    'stabilizationWindowSeconds': obj.stabilizationWindowSeconds,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+ *
+ * @schema io.k8s.api.autoscaling.v2.ContainerResourceMetricSource
+ */
+export interface ContainerResourceMetricSourceV2 {
+  /**
+   * container is the name of the container in the pods of the scaling target
+   *
+   * @schema io.k8s.api.autoscaling.v2.ContainerResourceMetricSource#container
+   */
+  readonly container: string;
+
+  /**
+   * name is the name of the resource in question.
+   *
+   * @schema io.k8s.api.autoscaling.v2.ContainerResourceMetricSource#name
+   */
+  readonly name: string;
+
+  /**
+   * target specifies the target value for the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.ContainerResourceMetricSource#target
+   */
+  readonly target: MetricTargetV2;
+
+}
+
+/**
+ * Converts an object of type 'ContainerResourceMetricSourceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ContainerResourceMetricSourceV2(obj: ContainerResourceMetricSourceV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'container': obj.container,
+    'name': obj.name,
+    'target': toJson_MetricTargetV2(obj.target),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+ *
+ * @schema io.k8s.api.autoscaling.v2.ExternalMetricSource
+ */
+export interface ExternalMetricSourceV2 {
+  /**
+   * metric identifies the target metric by name and selector
+   *
+   * @schema io.k8s.api.autoscaling.v2.ExternalMetricSource#metric
+   */
+  readonly metric: MetricIdentifierV2;
+
+  /**
+   * target specifies the target value for the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.ExternalMetricSource#target
+   */
+  readonly target: MetricTargetV2;
+
+}
+
+/**
+ * Converts an object of type 'ExternalMetricSourceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ExternalMetricSourceV2(obj: ExternalMetricSourceV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'metric': toJson_MetricIdentifierV2(obj.metric),
+    'target': toJson_MetricTargetV2(obj.target),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+ *
+ * @schema io.k8s.api.autoscaling.v2.ObjectMetricSource
+ */
+export interface ObjectMetricSourceV2 {
+  /**
+   * describedObject specifies the descriptions of a object,such as kind,name apiVersion
+   *
+   * @schema io.k8s.api.autoscaling.v2.ObjectMetricSource#describedObject
+   */
+  readonly describedObject: CrossVersionObjectReferenceV2;
+
+  /**
+   * metric identifies the target metric by name and selector
+   *
+   * @schema io.k8s.api.autoscaling.v2.ObjectMetricSource#metric
+   */
+  readonly metric: MetricIdentifierV2;
+
+  /**
+   * target specifies the target value for the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.ObjectMetricSource#target
+   */
+  readonly target: MetricTargetV2;
+
+}
+
+/**
+ * Converts an object of type 'ObjectMetricSourceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ObjectMetricSourceV2(obj: ObjectMetricSourceV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'describedObject': toJson_CrossVersionObjectReferenceV2(obj.describedObject),
+    'metric': toJson_MetricIdentifierV2(obj.metric),
+    'target': toJson_MetricTargetV2(obj.target),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+ *
+ * @schema io.k8s.api.autoscaling.v2.PodsMetricSource
+ */
+export interface PodsMetricSourceV2 {
+  /**
+   * metric identifies the target metric by name and selector
+   *
+   * @schema io.k8s.api.autoscaling.v2.PodsMetricSource#metric
+   */
+  readonly metric: MetricIdentifierV2;
+
+  /**
+   * target specifies the target value for the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.PodsMetricSource#target
+   */
+  readonly target: MetricTargetV2;
+
+}
+
+/**
+ * Converts an object of type 'PodsMetricSourceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_PodsMetricSourceV2(obj: PodsMetricSourceV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'metric': toJson_MetricIdentifierV2(obj.metric),
+    'target': toJson_MetricTargetV2(obj.target),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+ *
+ * @schema io.k8s.api.autoscaling.v2.ResourceMetricSource
+ */
+export interface ResourceMetricSourceV2 {
+  /**
+   * name is the name of the resource in question.
+   *
+   * @schema io.k8s.api.autoscaling.v2.ResourceMetricSource#name
+   */
+  readonly name: string;
+
+  /**
+   * target specifies the target value for the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.ResourceMetricSource#target
+   */
+  readonly target: MetricTargetV2;
+
+}
+
+/**
+ * Converts an object of type 'ResourceMetricSourceV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ResourceMetricSourceV2(obj: ResourceMetricSourceV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+    'target': toJson_MetricTargetV2(obj.target),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -24502,6 +24775,25 @@ export function toJson_ResourceMetricSourceV2Beta2(obj: ResourceMetricSourceV2Be
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Type of resource that this limit applies to.
+ *
+ * Possible enum values:
+ * - `"Container"` Limit that applies to all containers in a namespace
+ * - `"PersistentVolumeClaim"` Limit that applies to all persistent volume claims in a namespace
+ * - `"Pod"` Limit that applies to all pods in a namespace
+ *
+ * @schema IoK8SApiCoreV1LimitRangeItemType
+ */
+export enum IoK8SApiCoreV1LimitRangeItemType {
+  /** Container */
+  CONTAINER = 'Container',
+  /** PersistentVolumeClaim */
+  PERSISTENT_VOLUME_CLAIM = 'PersistentVolumeClaim',
+  /** Pod */
+  POD = 'Pod',
+}
+
+/**
  * ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node. This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
  *
  * @schema io.k8s.api.core.v1.ConfigMapNodeConfigSource
@@ -24561,6 +24853,25 @@ export function toJson_ConfigMapNodeConfigSource(obj: ConfigMapNodeConfigSource 
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+ *
+ * Possible enum values:
+ * - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+ * - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+ * - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+ *
+ * @schema IoK8SApiCoreV1TaintEffect
+ */
+export enum IoK8SApiCoreV1TaintEffect {
+  /** NoExecute */
+  NO_EXECUTE = 'NoExecute',
+  /** NoSchedule */
+  NO_SCHEDULE = 'NoSchedule',
+  /** PreferNoSchedule */
+  PREFER_NO_SCHEDULE = 'PreferNoSchedule',
+}
 
 /**
  * SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
@@ -24831,6 +25142,26 @@ export function toJson_EnvFromSource(obj: EnvFromSource | undefined): Record<str
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema IoK8SApiCoreV1ContainerImagePullPolicy
+ */
+export enum IoK8SApiCoreV1ContainerImagePullPolicy {
+  /** Always */
+  ALWAYS = 'Always',
+  /** IfNotPresent */
+  IF_NOT_PRESENT = 'IfNotPresent',
+  /** Never */
+  NEVER = 'Never',
+}
+
+/**
  * Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
  *
  * @schema io.k8s.api.core.v1.Lifecycle
@@ -24841,14 +25172,14 @@ export interface Lifecycle {
    *
    * @schema io.k8s.api.core.v1.Lifecycle#postStart
    */
-  readonly postStart?: Handler;
+  readonly postStart?: LifecycleHandler;
 
   /**
-   * PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+   * PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
    *
    * @schema io.k8s.api.core.v1.Lifecycle#preStop
    */
-  readonly preStop?: Handler;
+  readonly preStop?: LifecycleHandler;
 
 }
 
@@ -24859,8 +25190,8 @@ export interface Lifecycle {
 export function toJson_Lifecycle(obj: Lifecycle | undefined): Record<string, any> | undefined {
   if (obj === undefined) { return undefined; }
   const result = {
-    'postStart': toJson_Handler(obj.postStart),
-    'preStop': toJson_Handler(obj.preStop),
+    'postStart': toJson_LifecycleHandler(obj.postStart),
+    'preStop': toJson_LifecycleHandler(obj.preStop),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -24874,7 +25205,7 @@ export function toJson_Lifecycle(obj: Lifecycle | undefined): Record<string, any
  */
 export interface Probe {
   /**
-   * One and only one of the following should be specified. Exec specifies the action to take.
+   * Exec specifies the action to take.
    *
    * @schema io.k8s.api.core.v1.Probe#exec
    */
@@ -24887,6 +25218,13 @@ export interface Probe {
    * @schema io.k8s.api.core.v1.Probe#failureThreshold
    */
   readonly failureThreshold?: number;
+
+  /**
+   * GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+   *
+   * @schema io.k8s.api.core.v1.Probe#grpc
+   */
+  readonly grpc?: GrpcAction;
 
   /**
    * HTTPGet specifies the http request to perform.
@@ -24919,7 +25257,7 @@ export interface Probe {
   readonly successThreshold?: number;
 
   /**
-   * TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+   * TCPSocket specifies an action involving a TCP port.
    *
    * @schema io.k8s.api.core.v1.Probe#tcpSocket
    */
@@ -24951,6 +25289,7 @@ export function toJson_Probe(obj: Probe | undefined): Record<string, any> | unde
   const result = {
     'exec': toJson_ExecAction(obj.exec),
     'failureThreshold': obj.failureThreshold,
+    'grpc': toJson_GrpcAction(obj.grpc),
     'httpGet': toJson_HttpGetAction(obj.httpGet),
     'initialDelaySeconds': obj.initialDelaySeconds,
     'periodSeconds': obj.periodSeconds,
@@ -25001,10 +25340,15 @@ export interface ContainerPort {
   /**
    * Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
    *
+   * Possible enum values:
+   * - `"SCTP"` is the SCTP protocol.
+   * - `"TCP"` is the TCP protocol.
+   * - `"UDP"` is the UDP protocol.
+   *
    * @default TCP".
    * @schema io.k8s.api.core.v1.ContainerPort#protocol
    */
-  readonly protocol?: string;
+  readonly protocol?: IoK8SApiCoreV1ContainerPortProtocol;
 
 }
 
@@ -25033,45 +25377,45 @@ export function toJson_ContainerPort(obj: ContainerPort | undefined): Record<str
  */
 export interface SecurityContext {
   /**
-   * AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+   * AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#allowPrivilegeEscalation
    */
   readonly allowPrivilegeEscalation?: boolean;
 
   /**
-   * The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+   * The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
    *
-   * @default the default set of capabilities granted by the container runtime.
+   * @default the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
    * @schema io.k8s.api.core.v1.SecurityContext#capabilities
    */
   readonly capabilities?: Capabilities;
 
   /**
-   * Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+   * Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
    *
-   * @default false.
+   * @default false. Note that this field cannot be set when spec.os.name is windows.
    * @schema io.k8s.api.core.v1.SecurityContext#privileged
    */
   readonly privileged?: boolean;
 
   /**
-   * procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+   * procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#procMount
    */
   readonly procMount?: string;
 
   /**
-   * Whether this container has a read-only root filesystem. Default is false.
+   * Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
    *
-   * @default false.
+   * @default false. Note that this field cannot be set when spec.os.name is windows.
    * @schema io.k8s.api.core.v1.SecurityContext#readOnlyRootFilesystem
    */
   readonly readOnlyRootFilesystem?: boolean;
 
   /**
-   * The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#runAsGroup
    */
@@ -25085,29 +25429,29 @@ export interface SecurityContext {
   readonly runAsNonRoot?: boolean;
 
   /**
-   * The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
    *
-   * @default user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * @default user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
    * @schema io.k8s.api.core.v1.SecurityContext#runAsUser
    */
   readonly runAsUser?: number;
 
   /**
-   * The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#seLinuxOptions
    */
   readonly seLinuxOptions?: SeLinuxOptions;
 
   /**
-   * The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+   * The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#seccompProfile
    */
   readonly seccompProfile?: SeccompProfile;
 
   /**
-   * The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+   * The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
    *
    * @schema io.k8s.api.core.v1.SecurityContext#windowsOptions
    */
@@ -25138,6 +25482,23 @@ export function toJson_SecurityContext(obj: SecurityContext | undefined): Record
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+ *
+ * Possible enum values:
+ * - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+ * - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+ *
+ * @default File. Cannot be updated.
+ * @schema IoK8SApiCoreV1ContainerTerminationMessagePolicy
+ */
+export enum IoK8SApiCoreV1ContainerTerminationMessagePolicy {
+  /** FallbackToLogsOnError */
+  FALLBACK_TO_LOGS_ON_ERROR = 'FallbackToLogsOnError',
+  /** File */
+  FILE = 'File',
+}
 
 /**
  * volumeDevice describes a mapping of a raw block device within a container.
@@ -25284,6 +25645,65 @@ export function toJson_PodDnsConfigOption(obj: PodDnsConfigOption | undefined): 
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ *
+ * Possible enum values:
+ * - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+ * - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+ * - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+ *
+ * @default Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+ * @schema IoK8SApiCoreV1EphemeralContainerImagePullPolicy
+ */
+export enum IoK8SApiCoreV1EphemeralContainerImagePullPolicy {
+  /** Always */
+  ALWAYS = 'Always',
+  /** IfNotPresent */
+  IF_NOT_PRESENT = 'IfNotPresent',
+  /** Never */
+  NEVER = 'Never',
+}
+
+/**
+ * Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+ *
+ * Possible enum values:
+ * - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+ * - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+ *
+ * @default File. Cannot be updated.
+ * @schema IoK8SApiCoreV1EphemeralContainerTerminationMessagePolicy
+ */
+export enum IoK8SApiCoreV1EphemeralContainerTerminationMessagePolicy {
+  /** FallbackToLogsOnError */
+  FALLBACK_TO_LOGS_ON_ERROR = 'FallbackToLogsOnError',
+  /** File */
+  FILE = 'File',
+}
+
+/**
+ * ConditionType refers to a condition in the pod's condition list with matching type.
+ *
+ * Possible enum values:
+ * - `"ContainersReady"` indicates whether all containers in the pod are ready.
+ * - `"Initialized"` means that all init containers in the pod have started successfully.
+ * - `"PodScheduled"` represents status of the scheduling process for this pod.
+ * - `"Ready"` means the pod is able to service requests and should be added to the load balancing pools of all matching services.
+ *
+ * @schema IoK8SApiCoreV1PodReadinessGateConditionType
+ */
+export enum IoK8SApiCoreV1PodReadinessGateConditionType {
+  /** ContainersReady */
+  CONTAINERS_READY = 'ContainersReady',
+  /** Initialized */
+  INITIALIZED = 'Initialized',
+  /** PodScheduled */
+  POD_SCHEDULED = 'PodScheduled',
+  /** Ready */
+  READY = 'Ready',
+}
+
+/**
  * SELinuxOptions are the labels to be applied to the container
  *
  * @schema io.k8s.api.core.v1.SELinuxOptions
@@ -25354,9 +25774,14 @@ export interface SeccompProfile {
    *
    * Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
    *
+   * Possible enum values:
+   * - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+   * - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+   * - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+   *
    * @schema io.k8s.api.core.v1.SeccompProfile#type
    */
-  readonly type: string;
+  readonly type: IoK8SApiCoreV1SeccompProfileType;
 
 }
 
@@ -25465,6 +25890,61 @@ export function toJson_WindowsSecurityContextOptions(obj: WindowsSecurityContext
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+ *
+ * Possible enum values:
+ * - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+ * - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+ * - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+ *
+ * @schema IoK8SApiCoreV1TolerationEffect
+ */
+export enum IoK8SApiCoreV1TolerationEffect {
+  /** NoExecute */
+  NO_EXECUTE = 'NoExecute',
+  /** NoSchedule */
+  NO_SCHEDULE = 'NoSchedule',
+  /** PreferNoSchedule */
+  PREFER_NO_SCHEDULE = 'PreferNoSchedule',
+}
+
+/**
+ * Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ *
+ * Possible enum values:
+ * - `"Equal"`
+ * - `"Exists"`
+ *
+ * @default Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+ * @schema IoK8SApiCoreV1TolerationOperator
+ */
+export enum IoK8SApiCoreV1TolerationOperator {
+  /** Equal */
+  EQUAL = 'Equal',
+  /** Exists */
+  EXISTS = 'Exists',
+}
+
+/**
+ * WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+ * but giving higher precedence to topologies that would help reduce the
+ * skew.
+ * A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+ *
+ * Possible enum values:
+ * - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+ * - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+ *
+ * @schema IoK8SApiCoreV1TopologySpreadConstraintWhenUnsatisfiable
+ */
+export enum IoK8SApiCoreV1TopologySpreadConstraintWhenUnsatisfiable {
+  /** DoNotSchedule */
+  DO_NOT_SCHEDULE = 'DoNotSchedule',
+  /** ScheduleAnyway */
+  SCHEDULE_ANYWAY = 'ScheduleAnyway',
+}
 
 /**
  * AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
@@ -26525,16 +27005,30 @@ export interface ScopedResourceSelectorRequirement {
   /**
    * Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
    *
+   * Possible enum values:
+   * - `"DoesNotExist"`
+   * - `"Exists"`
+   * - `"In"`
+   * - `"NotIn"`
+   *
    * @schema io.k8s.api.core.v1.ScopedResourceSelectorRequirement#operator
    */
-  readonly operator: string;
+  readonly operator: IoK8SApiCoreV1ScopedResourceSelectorRequirementOperator;
 
   /**
    * The name of the scope that the selector applies to.
    *
+   * Possible enum values:
+   * - `"BestEffort"` Match all pod objects that have best effort quality of service
+   * - `"CrossNamespacePodAffinity"` Match all pod objects that have cross-namespace pod (anti)affinity mentioned. This is a beta feature enabled by the PodAffinityNamespaceSelector feature flag.
+   * - `"NotBestEffort"` Match all pod objects that do not have best effort quality of service
+   * - `"NotTerminating"` Match all pod objects where spec.activeDeadlineSeconds is nil
+   * - `"PriorityClass"` Match all pod objects that have priority class mentioned
+   * - `"Terminating"` Match all pod objects where spec.activeDeadlineSeconds >=0
+   *
    * @schema io.k8s.api.core.v1.ScopedResourceSelectorRequirement#scopeName
    */
-  readonly scopeName: string;
+  readonly scopeName: IoK8SApiCoreV1ScopedResourceSelectorRequirementScopeName;
 
   /**
    * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
@@ -26560,6 +27054,26 @@ export function toJson_ScopedResourceSelectorRequirement(obj: ScopedResourceSele
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+ *
+ * Possible enum values:
+ * - `"SCTP"` is the SCTP protocol.
+ * - `"TCP"` is the TCP protocol.
+ * - `"UDP"` is the UDP protocol.
+ *
+ * @default TCP.
+ * @schema IoK8SApiCoreV1ServicePortProtocol
+ */
+export enum IoK8SApiCoreV1ServicePortProtocol {
+  /** SCTP */
+  SCTP = 'SCTP',
+  /** TCP */
+  TCP = 'TCP',
+  /** UDP */
+  UDP = 'UDP',
+}
 
 /**
  * ClientIPConfig represents the configurations of Client IP based session affinity.
@@ -26692,7 +27206,7 @@ export function toJson_NonResourcePolicyRuleV1Beta1(obj: NonResourcePolicyRuleV1
 /* eslint-enable max-len, quote-props */
 
 /**
- * ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.
+ * ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
  *
  * @schema io.k8s.api.flowcontrol.v1beta1.ResourcePolicyRule
  */
@@ -26835,6 +27349,200 @@ export function toJson_LimitResponseV1Beta1(obj: LimitResponseV1Beta1 | undefine
   if (obj === undefined) { return undefined; }
   const result = {
     'queuing': toJson_QueuingConfigurationV1Beta1(obj.queuing),
+    'type': obj.type,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule
+ */
+export interface NonResourcePolicyRuleV1Beta2 {
+  /**
+   * `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+   * - "/healthz" is legal
+   * - "/hea*" is illegal
+   * - "/hea" is legal but matches nothing
+   * - "/hea/*" also matches nothing
+   * - "/healthz/*" matches all per-component health checks.
+   * "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule#nonResourceURLs
+   */
+  readonly nonResourceUrLs: string[];
+
+  /**
+   * `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.NonResourcePolicyRule#verbs
+   */
+  readonly verbs: string[];
+
+}
+
+/**
+ * Converts an object of type 'NonResourcePolicyRuleV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_NonResourcePolicyRuleV1Beta2(obj: NonResourcePolicyRuleV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'nonResourceURLs': obj.nonResourceUrLs?.map(y => y),
+    'verbs': obj.verbs?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule
+ */
+export interface ResourcePolicyRuleV1Beta2 {
+  /**
+   * `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule#apiGroups
+   */
+  readonly apiGroups: string[];
+
+  /**
+   * `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule#clusterScope
+   */
+  readonly clusterScope?: boolean;
+
+  /**
+   * `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule#namespaces
+   */
+  readonly namespaces?: string[];
+
+  /**
+   * `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule#resources
+   */
+  readonly resources: string[];
+
+  /**
+   * `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ResourcePolicyRule#verbs
+   */
+  readonly verbs: string[];
+
+}
+
+/**
+ * Converts an object of type 'ResourcePolicyRuleV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ResourcePolicyRuleV1Beta2(obj: ResourcePolicyRuleV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'apiGroups': obj.apiGroups?.map(y => y),
+    'clusterScope': obj.clusterScope,
+    'namespaces': obj.namespaces?.map(y => y),
+    'resources': obj.resources?.map(y => y),
+    'verbs': obj.verbs?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.Subject
+ */
+export interface SubjectV1Beta2 {
+  /**
+   * `group` matches based on user group name.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.Subject#group
+   */
+  readonly group?: GroupSubjectV1Beta2;
+
+  /**
+   * `kind` indicates which one of the other fields is non-empty. Required
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.Subject#kind
+   */
+  readonly kind: string;
+
+  /**
+   * `serviceAccount` matches ServiceAccounts.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.Subject#serviceAccount
+   */
+  readonly serviceAccount?: ServiceAccountSubjectV1Beta2;
+
+  /**
+   * `user` matches based on username.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.Subject#user
+   */
+  readonly user?: UserSubjectV1Beta2;
+
+}
+
+/**
+ * Converts an object of type 'SubjectV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_SubjectV1Beta2(obj: SubjectV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'group': toJson_GroupSubjectV1Beta2(obj.group),
+    'kind': obj.kind,
+    'serviceAccount': toJson_ServiceAccountSubjectV1Beta2(obj.serviceAccount),
+    'user': toJson_UserSubjectV1Beta2(obj.user),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * LimitResponse defines how to handle requests that can not be executed right now.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.LimitResponse
+ */
+export interface LimitResponseV1Beta2 {
+  /**
+   * `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.LimitResponse#queuing
+   */
+  readonly queuing?: QueuingConfigurationV1Beta2;
+
+  /**
+   * `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.LimitResponse#type
+   */
+  readonly type: string;
+
+}
+
+/**
+ * Converts an object of type 'LimitResponseV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_LimitResponseV1Beta2(obj: LimitResponseV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'queuing': toJson_QueuingConfigurationV1Beta2(obj.queuing),
     'type': obj.type,
   };
   // filter undefined values
@@ -27234,6 +27942,141 @@ export function toJson_CustomResourceSubresources(obj: CustomResourceSubresource
   const result = {
     'scale': toJson_CustomResourceSubresourceScale(obj.scale),
     'status': obj.status,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * HPAScalingPolicy is a single policy which must hold true for a specified past interval.
+ *
+ * @schema io.k8s.api.autoscaling.v2.HPAScalingPolicy
+ */
+export interface HpaScalingPolicyV2 {
+  /**
+   * PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingPolicy#periodSeconds
+   */
+  readonly periodSeconds: number;
+
+  /**
+   * Type is used to specify the scaling policy.
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingPolicy#type
+   */
+  readonly type: string;
+
+  /**
+   * Value contains the amount of change which is permitted by the policy. It must be greater than zero
+   *
+   * @schema io.k8s.api.autoscaling.v2.HPAScalingPolicy#value
+   */
+  readonly value: number;
+
+}
+
+/**
+ * Converts an object of type 'HpaScalingPolicyV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_HpaScalingPolicyV2(obj: HpaScalingPolicyV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'periodSeconds': obj.periodSeconds,
+    'type': obj.type,
+    'value': obj.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * MetricTarget defines the target value, average value, or average utilization of a specific metric
+ *
+ * @schema io.k8s.api.autoscaling.v2.MetricTarget
+ */
+export interface MetricTargetV2 {
+  /**
+   * averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricTarget#averageUtilization
+   */
+  readonly averageUtilization?: number;
+
+  /**
+   * averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricTarget#averageValue
+   */
+  readonly averageValue?: Quantity;
+
+  /**
+   * type represents whether the metric type is Utilization, Value, or AverageValue
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricTarget#type
+   */
+  readonly type: string;
+
+  /**
+   * value is the target value of the metric (as a quantity).
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricTarget#value
+   */
+  readonly value?: Quantity;
+
+}
+
+/**
+ * Converts an object of type 'MetricTargetV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MetricTargetV2(obj: MetricTargetV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'averageUtilization': obj.averageUtilization,
+    'averageValue': obj.averageValue?.value,
+    'type': obj.type,
+    'value': obj.value?.value,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * MetricIdentifier defines the name and optionally selector for a metric
+ *
+ * @schema io.k8s.api.autoscaling.v2.MetricIdentifier
+ */
+export interface MetricIdentifierV2 {
+  /**
+   * name is the name of the given metric
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricIdentifier#name
+   */
+  readonly name: string;
+
+  /**
+   * selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+   *
+   * @schema io.k8s.api.autoscaling.v2.MetricIdentifier#selector
+   */
+  readonly selector?: LabelSelector;
+
+}
+
+/**
+ * Converts an object of type 'MetricIdentifierV2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_MetricIdentifierV2(obj: MetricIdentifierV2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+    'selector': toJson_LabelSelector(obj.selector),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -27671,39 +28514,39 @@ export function toJson_SecretEnvSource(obj: SecretEnvSource | undefined): Record
 /* eslint-enable max-len, quote-props */
 
 /**
- * Handler defines a specific action that should be taken
+ * LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.
  *
- * @schema io.k8s.api.core.v1.Handler
+ * @schema io.k8s.api.core.v1.LifecycleHandler
  */
-export interface Handler {
+export interface LifecycleHandler {
   /**
-   * One and only one of the following should be specified. Exec specifies the action to take.
+   * Exec specifies the action to take.
    *
-   * @schema io.k8s.api.core.v1.Handler#exec
+   * @schema io.k8s.api.core.v1.LifecycleHandler#exec
    */
   readonly exec?: ExecAction;
 
   /**
    * HTTPGet specifies the http request to perform.
    *
-   * @schema io.k8s.api.core.v1.Handler#httpGet
+   * @schema io.k8s.api.core.v1.LifecycleHandler#httpGet
    */
   readonly httpGet?: HttpGetAction;
 
   /**
-   * TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported
+   * Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
    *
-   * @schema io.k8s.api.core.v1.Handler#tcpSocket
+   * @schema io.k8s.api.core.v1.LifecycleHandler#tcpSocket
    */
   readonly tcpSocket?: TcpSocketAction;
 
 }
 
 /**
- * Converts an object of type 'Handler' to JSON representation.
+ * Converts an object of type 'LifecycleHandler' to JSON representation.
  */
 /* eslint-disable max-len, quote-props */
-export function toJson_Handler(obj: Handler | undefined): Record<string, any> | undefined {
+export function toJson_LifecycleHandler(obj: LifecycleHandler | undefined): Record<string, any> | undefined {
   if (obj === undefined) { return undefined; }
   const result = {
     'exec': toJson_ExecAction(obj.exec),
@@ -27738,6 +28581,43 @@ export function toJson_ExecAction(obj: ExecAction | undefined): Record<string, a
   if (obj === undefined) { return undefined; }
   const result = {
     'command': obj.command?.map(y => y),
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * @schema io.k8s.api.core.v1.GRPCAction
+ */
+export interface GrpcAction {
+  /**
+   * Port number of the gRPC service. Number must be in the range 1 to 65535.
+   *
+   * @schema io.k8s.api.core.v1.GRPCAction#port
+   */
+  readonly port: number;
+
+  /**
+   * Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+   *
+   * If this is not specified, the default behavior is defined by gRPC.
+   *
+   * @schema io.k8s.api.core.v1.GRPCAction#service
+   */
+  readonly service?: string;
+
+}
+
+/**
+ * Converts an object of type 'GrpcAction' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_GrpcAction(obj: GrpcAction | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'port': obj.port,
+    'service': obj.service,
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -27781,10 +28661,14 @@ export interface HttpGetAction {
   /**
    * Scheme to use for connecting to the host. Defaults to HTTP.
    *
+   * Possible enum values:
+   * - `"HTTP"` means that the scheme used will be http://
+   * - `"HTTPS"` means that the scheme used will be https://
+   *
    * @default HTTP.
    * @schema io.k8s.api.core.v1.HTTPGetAction#scheme
    */
-  readonly scheme?: string;
+  readonly scheme?: IoK8SApiCoreV1HttpGetActionScheme;
 
 }
 
@@ -27844,6 +28728,26 @@ export function toJson_TcpSocketAction(obj: TcpSocketAction | undefined): Record
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+ *
+ * Possible enum values:
+ * - `"SCTP"` is the SCTP protocol.
+ * - `"TCP"` is the TCP protocol.
+ * - `"UDP"` is the UDP protocol.
+ *
+ * @default TCP".
+ * @schema IoK8SApiCoreV1ContainerPortProtocol
+ */
+export enum IoK8SApiCoreV1ContainerPortProtocol {
+  /** SCTP */
+  SCTP = 'SCTP',
+  /** TCP */
+  TCP = 'TCP',
+  /** UDP */
+  UDP = 'UDP',
+}
+
+/**
  * Adds and removes POSIX capabilities from running containers.
  *
  * @schema io.k8s.api.core.v1.Capabilities
@@ -27879,6 +28783,27 @@ export function toJson_Capabilities(obj: Capabilities | undefined): Record<strin
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * type indicates which kind of seccomp profile will be applied. Valid options are:
+ *
+ * Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+ *
+ * Possible enum values:
+ * - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+ * - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+ * - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+ *
+ * @schema IoK8SApiCoreV1SeccompProfileType
+ */
+export enum IoK8SApiCoreV1SeccompProfileType {
+  /** Localhost */
+  LOCALHOST = 'Localhost',
+  /** RuntimeDefault */
+  RUNTIME_DEFAULT = 'RuntimeDefault',
+  /** Unconfined */
+  UNCONFINED = 'Unconfined',
+}
 
 /**
  * Maps a string key to a path within a volume.
@@ -28069,6 +28994,56 @@ export function toJson_VolumeProjection(obj: VolumeProjection | undefined): Reco
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+ *
+ * Possible enum values:
+ * - `"DoesNotExist"`
+ * - `"Exists"`
+ * - `"In"`
+ * - `"NotIn"`
+ *
+ * @schema IoK8SApiCoreV1ScopedResourceSelectorRequirementOperator
+ */
+export enum IoK8SApiCoreV1ScopedResourceSelectorRequirementOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = 'DoesNotExist',
+  /** Exists */
+  EXISTS = 'Exists',
+  /** In */
+  IN = 'In',
+  /** NotIn */
+  NOT_IN = 'NotIn',
+}
+
+/**
+ * The name of the scope that the selector applies to.
+ *
+ * Possible enum values:
+ * - `"BestEffort"` Match all pod objects that have best effort quality of service
+ * - `"CrossNamespacePodAffinity"` Match all pod objects that have cross-namespace pod (anti)affinity mentioned. This is a beta feature enabled by the PodAffinityNamespaceSelector feature flag.
+ * - `"NotBestEffort"` Match all pod objects that do not have best effort quality of service
+ * - `"NotTerminating"` Match all pod objects where spec.activeDeadlineSeconds is nil
+ * - `"PriorityClass"` Match all pod objects that have priority class mentioned
+ * - `"Terminating"` Match all pod objects where spec.activeDeadlineSeconds >=0
+ *
+ * @schema IoK8SApiCoreV1ScopedResourceSelectorRequirementScopeName
+ */
+export enum IoK8SApiCoreV1ScopedResourceSelectorRequirementScopeName {
+  /** BestEffort */
+  BEST_EFFORT = 'BestEffort',
+  /** CrossNamespacePodAffinity */
+  CROSS_NAMESPACE_POD_AFFINITY = 'CrossNamespacePodAffinity',
+  /** NotBestEffort */
+  NOT_BEST_EFFORT = 'NotBestEffort',
+  /** NotTerminating */
+  NOT_TERMINATING = 'NotTerminating',
+  /** PriorityClass */
+  PRIORITY_CLASS = 'PriorityClass',
+  /** Terminating */
+  TERMINATING = 'Terminating',
+}
+
+/**
  * GroupSubject holds detailed information for group-kind subject.
  *
  * @schema io.k8s.api.flowcontrol.v1beta1.GroupSubject
@@ -28197,6 +29172,146 @@ export interface QueuingConfigurationV1Beta1 {
  */
 /* eslint-disable max-len, quote-props */
 export function toJson_QueuingConfigurationV1Beta1(obj: QueuingConfigurationV1Beta1 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'handSize': obj.handSize,
+    'queueLengthLimit': obj.queueLengthLimit,
+    'queues': obj.queues,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * GroupSubject holds detailed information for group-kind subject.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.GroupSubject
+ */
+export interface GroupSubjectV1Beta2 {
+  /**
+   * name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.GroupSubject#name
+   */
+  readonly name: string;
+
+}
+
+/**
+ * Converts an object of type 'GroupSubjectV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_GroupSubjectV1Beta2(obj: GroupSubjectV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * ServiceAccountSubject holds detailed information for service-account-kind subject.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject
+ */
+export interface ServiceAccountSubjectV1Beta2 {
+  /**
+   * `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject#name
+   */
+  readonly name: string;
+
+  /**
+   * `namespace` is the namespace of matching ServiceAccount objects. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.ServiceAccountSubject#namespace
+   */
+  readonly namespace: string;
+
+}
+
+/**
+ * Converts an object of type 'ServiceAccountSubjectV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ServiceAccountSubjectV1Beta2(obj: ServiceAccountSubjectV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+    'namespace': obj.namespace,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * UserSubject holds detailed information for user-kind subject.
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.UserSubject
+ */
+export interface UserSubjectV1Beta2 {
+  /**
+   * `name` is the username that matches, or "*" to match all usernames. Required.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.UserSubject#name
+   */
+  readonly name: string;
+
+}
+
+/**
+ * Converts an object of type 'UserSubjectV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_UserSubjectV1Beta2(obj: UserSubjectV1Beta2 | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'name': obj.name,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * QueuingConfiguration holds the configuration parameters for queuing
+ *
+ * @schema io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration
+ */
+export interface QueuingConfigurationV1Beta2 {
+  /**
+   * `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration#handSize
+   */
+  readonly handSize?: number;
+
+  /**
+   * `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration#queueLengthLimit
+   */
+  readonly queueLengthLimit?: number;
+
+  /**
+   * `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+   *
+   * @schema io.k8s.api.flowcontrol.v1beta2.QueuingConfiguration#queues
+   */
+  readonly queues?: number;
+
+}
+
+/**
+ * Converts an object of type 'QueuingConfigurationV1Beta2' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_QueuingConfigurationV1Beta2(obj: QueuingConfigurationV1Beta2 | undefined): Record<string, any> | undefined {
   if (obj === undefined) { return undefined; }
   const result = {
     'handSize': obj.handSize,
@@ -28610,6 +29725,13 @@ export interface JsonSchemaProps {
    */
   readonly xKubernetesPreserveUnknownFields?: boolean;
 
+  /**
+   * x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
+   *
+   * @schema io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps#x-kubernetes-validations
+   */
+  readonly xKubernetesValidations?: ValidationRule[];
+
 }
 
 /**
@@ -28662,6 +29784,7 @@ export function toJson_JsonSchemaProps(obj: JsonSchemaProps | undefined): Record
     'x-kubernetes-list-type': obj.xKubernetesListType,
     'x-kubernetes-map-type': obj.xKubernetesMapType,
     'x-kubernetes-preserve-unknown-fields': obj.xKubernetesPreserveUnknownFields,
+    'x-kubernetes-validations': obj.xKubernetesValidations?.map(y => toJson_ValidationRule(y)),
   };
   // filter undefined values
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
@@ -28729,9 +29852,17 @@ export interface NodeSelectorRequirement {
   /**
    * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
    *
+   * Possible enum values:
+   * - `"DoesNotExist"`
+   * - `"Exists"`
+   * - `"Gt"`
+   * - `"In"`
+   * - `"Lt"`
+   * - `"NotIn"`
+   *
    * @schema io.k8s.api.core.v1.NodeSelectorRequirement#operator
    */
-  readonly operator: string;
+  readonly operator: IoK8SApiCoreV1NodeSelectorRequirementOperator;
 
   /**
    * An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
@@ -28968,6 +30099,23 @@ export function toJson_HttpHeader(obj: HttpHeader | undefined): Record<string, a
 /* eslint-enable max-len, quote-props */
 
 /**
+ * Scheme to use for connecting to the host. Defaults to HTTP.
+ *
+ * Possible enum values:
+ * - `"HTTP"` means that the scheme used will be http://
+ * - `"HTTPS"` means that the scheme used will be https://
+ *
+ * @default HTTP.
+ * @schema IoK8SApiCoreV1HttpGetActionScheme
+ */
+export enum IoK8SApiCoreV1HttpGetActionScheme {
+  /** HTTP */
+  HTTP = 'HTTP',
+  /** HTTPS */
+  HTTPS = 'HTTPS',
+}
+
+/**
  * Adapts a ConfigMap into a projected volume.
  *
  * The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
@@ -29168,4 +30316,93 @@ export function toJson_ExternalDocumentation(obj: ExternalDocumentation | undefi
   return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
 }
 /* eslint-enable max-len, quote-props */
+
+/**
+ * ValidationRule describes a validation rule written in the CEL expression language.
+ *
+ * @schema io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule
+ */
+export interface ValidationRule {
+  /**
+   * Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host"
+   *
+   * @schema io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule#message
+   */
+  readonly message?: string;
+
+  /**
+   * Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {"rule": "self.status.actual <= self.spec.maxDesired"}
+   *
+   * If the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {"rule": "self.components['Widget'].priority < 10"} - Rule scoped to a list of integers: {"rule": "self.values.all(value, value >= 0 && value < 100)"} - Rule scoped to a string value: {"rule": "self.startsWith('kube')"}
+   *
+   * The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.
+   *
+   * Unknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an "unknown type". An "unknown type" is recursively defined as:
+   * - A schema with no type and x-kubernetes-preserve-unknown-fields set to true
+   * - An array where the items schema is of an "unknown type"
+   * - An object where the additionalProperties schema is of an "unknown type"
+   *
+   * Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+   * "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+   * "import", "let", "loop", "package", "namespace", "return".
+   * Examples:
+   * - Rule accessing a property named "namespace": {"rule": "self.__namespace__ > 0"}
+   * - Rule accessing a property named "x-prop": {"rule": "self.x__dash__prop > 0"}
+   * - Rule accessing a property named "redact__d": {"rule": "self.redact__underscores__d > 0"}
+   *
+   * Equality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+   * - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+   * non-intersecting elements in `Y` are appended, retaining their partial order.
+   * - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+   * are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+   * non-intersecting keys are appended, retaining their partial order.
+   *
+   * @schema io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule#rule
+   */
+  readonly rule: string;
+
+}
+
+/**
+ * Converts an object of type 'ValidationRule' to JSON representation.
+ */
+/* eslint-disable max-len, quote-props */
+export function toJson_ValidationRule(obj: ValidationRule | undefined): Record<string, any> | undefined {
+  if (obj === undefined) { return undefined; }
+  const result = {
+    'message': obj.message,
+    'rule': obj.rule,
+  };
+  // filter undefined values
+  return Object.entries(result).reduce((r, i) => (i[1] === undefined) ? r : ({ ...r, [i[0]]: i[1] }), {});
+}
+/* eslint-enable max-len, quote-props */
+
+/**
+ * Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+ *
+ * Possible enum values:
+ * - `"DoesNotExist"`
+ * - `"Exists"`
+ * - `"Gt"`
+ * - `"In"`
+ * - `"Lt"`
+ * - `"NotIn"`
+ *
+ * @schema IoK8SApiCoreV1NodeSelectorRequirementOperator
+ */
+export enum IoK8SApiCoreV1NodeSelectorRequirementOperator {
+  /** DoesNotExist */
+  DOES_NOT_EXIST = 'DoesNotExist',
+  /** Exists */
+  EXISTS = 'Exists',
+  /** Gt */
+  GT = 'Gt',
+  /** In */
+  IN = 'In',
+  /** Lt */
+  LT = 'Lt',
+  /** NotIn */
+  NOT_IN = 'NotIn',
+}
 

--- a/lib/background-worker/background-worker-props.ts
+++ b/lib/background-worker/background-worker-props.ts
@@ -1,3 +1,4 @@
+import { IoK8SApiCoreV1PodSpecRestartPolicy } from "../../imports/k8s";
 import { ContainerProps, WorkloadProps } from "../common";
 
 export interface BackgroundWorkerProps
@@ -18,7 +19,7 @@ export interface BackgroundWorkerProps
 
   /**
    * Restart policy for all containers within the pod.
-   * @default "Always"
+   * @default IoK8SApiCoreV1PodSpecRestartPolicy.ALWAYS
    */
-  readonly restartPolicy?: "Always";
+  readonly restartPolicy?: IoK8SApiCoreV1PodSpecRestartPolicy;
 }

--- a/lib/background-worker/background-worker.ts
+++ b/lib/background-worker/background-worker.ts
@@ -1,6 +1,10 @@
 import { Chart } from "cdk8s";
 import { Construct } from "constructs";
-import { KubeDeployment, Lifecycle } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  KubeDeployment,
+  Lifecycle,
+} from "../../imports/k8s";
 import { defaultAffinity } from "../common";
 import { BackgroundWorkerProps } from "./background-worker-props";
 
@@ -60,7 +64,9 @@ export class BackgroundWorker extends Construct {
               {
                 name: props.containerName ?? app ?? "app",
                 image: props.image,
-                imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+                imagePullPolicy:
+                  props.imagePullPolicy ??
+                  IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT,
                 workingDir: props.workingDir,
                 command: props.command,
                 args: props.args,

--- a/lib/common/container-props.ts
+++ b/lib/common/container-props.ts
@@ -2,6 +2,7 @@ import {
   Container,
   EnvFromSource,
   EnvVar,
+  IoK8SApiCoreV1ContainerImagePullPolicy,
   Lifecycle,
   Probe,
   ResourceRequirements,
@@ -21,9 +22,9 @@ export interface ContainerProps {
 
   /**
    * Affects when the kubelet attempts to pull the specified image.
-   * @default IfNotPresent
+   * @default IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT
    */
-  readonly imagePullPolicy?: "Always" | "Never" | "IfNotPresent";
+  readonly imagePullPolicy?: IoK8SApiCoreV1ContainerImagePullPolicy;
 
   /** Release version of the Docker image. */
   readonly release: string;

--- a/lib/cron-job/cron-job-props.ts
+++ b/lib/cron-job/cron-job-props.ts
@@ -1,5 +1,9 @@
 import { ContainerProps } from "../common";
-import { LocalObjectReference, Volume } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  LocalObjectReference,
+  Volume,
+} from "../../imports/k8s";
 
 export interface CronJobProps
   extends Omit<
@@ -35,7 +39,7 @@ export interface CronJobProps
   /**
    * Restart policy for all containers within the pod.
    */
-  readonly restartPolicy: "OnFailure" | "Never";
+  readonly restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy;
 
   /**
    * Specifies the number of retries before marking this job failed.

--- a/lib/cron-job/cron-job.ts
+++ b/lib/cron-job/cron-job.ts
@@ -1,6 +1,9 @@
 import { Chart } from "cdk8s";
 import { Construct } from "constructs";
-import { KubeCronJob } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  KubeCronJob,
+} from "../../imports/k8s";
 import { CronJobProps } from "./cron-job-props";
 import { parseExpression } from "cron-parser";
 
@@ -52,7 +55,9 @@ export class CronJob extends Construct {
                   {
                     name: props.containerName ?? app ?? "app",
                     image: props.image,
-                    imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+                    imagePullPolicy:
+                      props.imagePullPolicy ??
+                      IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT,
                     workingDir: props.workingDir,
                     command: props.command,
                     args: props.args,

--- a/lib/job/job-props.ts
+++ b/lib/job/job-props.ts
@@ -1,5 +1,9 @@
 import { ContainerProps } from "../common";
-import { LocalObjectReference, Volume } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  LocalObjectReference,
+  Volume,
+} from "../../imports/k8s";
 
 export interface JobProps
   extends Omit<
@@ -26,7 +30,7 @@ export interface JobProps
   /**
    * Restart policy for all containers within the pod.
    */
-  readonly restartPolicy: "OnFailure" | "Never";
+  readonly restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy;
 
   /**
    * Specifies the number of retries before marking this job failed.

--- a/lib/job/job.ts
+++ b/lib/job/job.ts
@@ -1,6 +1,9 @@
 import { Chart } from "cdk8s";
 import { Construct } from "constructs";
-import { KubeJob } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  KubeJob,
+} from "../../imports/k8s";
 import { JobProps } from "./job-props";
 
 export class Job extends Construct {
@@ -44,7 +47,9 @@ export class Job extends Construct {
               {
                 name: props.containerName ?? app ?? "app",
                 image: props.image,
-                imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+                imagePullPolicy:
+                  props.imagePullPolicy ??
+                  IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT,
                 workingDir: props.workingDir,
                 command: props.command,
                 args: props.args,

--- a/lib/memcached/memcached.ts
+++ b/lib/memcached/memcached.ts
@@ -2,6 +2,7 @@ import { Chart } from "cdk8s";
 import { Construct } from "constructs";
 import {
   IntOrString,
+  IoK8SApiCoreV1ServicePortProtocol,
   KubeService,
   KubeStatefulSet,
   Quantity,
@@ -47,7 +48,7 @@ export class Memcached extends Construct {
         ports: [
           {
             port: port,
-            protocol: "TCP",
+            protocol: IoK8SApiCoreV1ServicePortProtocol.TCP,
           },
         ],
         selector: selectorLabels,

--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -2,6 +2,7 @@ import { Chart } from "cdk8s";
 import { Construct } from "constructs";
 import {
   IntOrString,
+  IoK8SApiCoreV1ServicePortProtocol,
   KubeService,
   KubeStatefulSet,
   Quantity,
@@ -54,7 +55,7 @@ export class Mongo extends Construct {
         ports: [
           {
             port: port,
-            protocol: "TCP",
+            protocol: IoK8SApiCoreV1ServicePortProtocol.TCP,
           },
         ],
         selector: selectorLabels,

--- a/lib/postgres/postgres.ts
+++ b/lib/postgres/postgres.ts
@@ -1,6 +1,11 @@
 import { Chart } from "cdk8s";
 import { Construct } from "constructs";
-import { KubeService, KubeStatefulSet, Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ServicePortProtocol,
+  KubeService,
+  KubeStatefulSet,
+  Quantity,
+} from "../../imports/k8s";
 import { PostgresProps } from "./postgres-props";
 
 export class Postgres extends Construct {
@@ -47,7 +52,7 @@ export class Postgres extends Construct {
         ports: [
           {
             port: port,
-            protocol: "TCP",
+            protocol: IoK8SApiCoreV1ServicePortProtocol.TCP,
           },
         ],
         selector: selectorLabels,

--- a/lib/redis/redis.ts
+++ b/lib/redis/redis.ts
@@ -2,6 +2,7 @@ import { Chart } from "cdk8s";
 import { Construct } from "constructs";
 import {
   IntOrString,
+  IoK8SApiCoreV1ServicePortProtocol,
   KubeService,
   KubeStatefulSet,
   Quantity,
@@ -45,7 +46,7 @@ export class Redis extends Construct {
         ports: [
           {
             port: port,
-            protocol: "TCP",
+            protocol: IoK8SApiCoreV1ServicePortProtocol.TCP,
           },
         ],
         selector: selectorLabels,

--- a/lib/talis-chart/calculate-resource-quota.ts
+++ b/lib/talis-chart/calculate-resource-quota.ts
@@ -5,8 +5,8 @@ import {
   CronJobSpec,
   DaemonSetSpec,
   DeploymentSpec,
-  HorizontalPodAutoscalerSpecV2Beta2,
-  KubeHorizontalPodAutoscalerV2Beta2,
+  HorizontalPodAutoscalerSpecV2,
+  KubeHorizontalPodAutoscalerV2,
   ObjectMeta,
   PodSpec,
   Quantity,
@@ -34,7 +34,7 @@ interface KubeObject {
     DeploymentSpec &
     ReplicaSetSpec &
     StatefulSetSpec &
-    HorizontalPodAutoscalerSpecV2Beta2;
+    HorizontalPodAutoscalerSpecV2;
 }
 
 function cpuToMillicores(cpu: Quantity | string | number): number {
@@ -151,7 +151,7 @@ export function calculateResourceQuota(
     workloads.set(key, kubeObject);
   }
 
-  function addMaxReplicas(object: KubeHorizontalPodAutoscalerV2Beta2) {
+  function addMaxReplicas(object: KubeHorizontalPodAutoscalerV2) {
     const hpa = object.toJson() as KubeObject;
     const target = hpa.spec.scaleTargetRef;
     const key = target.kind + "/" + target.name;

--- a/lib/web-service/web-service-props.ts
+++ b/lib/web-service/web-service-props.ts
@@ -1,4 +1,8 @@
-import { Probe, ResourceRequirements } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  Probe,
+  ResourceRequirements,
+} from "../../imports/k8s";
 import { ContainerProps, WorkloadProps } from "../common";
 
 export const canaryStages = ["base", "canary", "post-canary", "full"] as const;
@@ -24,9 +28,9 @@ export interface NginxContainerProps {
 
   /**
    * Affects when the kubelet attempts to pull the specified image.
-   * @default IfNotPresent
+   * @default IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT
    */
-  readonly imagePullPolicy?: "Always" | "Never" | "IfNotPresent";
+  readonly imagePullPolicy?: IoK8SApiCoreV1ContainerImagePullPolicy;
 
   /**
    * Port (what container will listen on).

--- a/lib/web-service/web-service.ts
+++ b/lib/web-service/web-service.ts
@@ -6,10 +6,10 @@ import {
   IngressTls,
   IntOrString,
   KubeDeployment,
-  KubeHorizontalPodAutoscalerV2Beta2,
+  KubeHorizontalPodAutoscalerV2,
   KubeIngress,
   KubeService,
-  MetricSpecV2Beta2,
+  MetricSpecV2,
   Quantity,
   Volume,
 } from "../../imports/k8s";
@@ -30,7 +30,7 @@ export class WebService extends Construct {
   readonly canaryIngress?: KubeIngress;
   readonly deployment!: KubeDeployment;
   readonly canaryDeployment?: KubeDeployment;
-  readonly hpa?: KubeHorizontalPodAutoscalerV2Beta2;
+  readonly hpa?: KubeHorizontalPodAutoscalerV2;
 
   constructor(scope: Construct, id: string, props: WebServiceProps) {
     super(scope, id);
@@ -486,7 +486,7 @@ export class WebService extends Construct {
     props: HorizontalPodAutoscalerProps,
     labels: { [key: string]: string }
   ) {
-    const metrics: Array<MetricSpecV2Beta2> = [];
+    const metrics: Array<MetricSpecV2> = [];
 
     if (props.cpuTargetUtilization) {
       metrics.push({
@@ -514,7 +514,7 @@ export class WebService extends Construct {
       });
     }
 
-    return new KubeHorizontalPodAutoscalerV2Beta2(
+    return new KubeHorizontalPodAutoscalerV2(
       this,
       `${deployment.node.id}-hpa`,
       {

--- a/lib/web-service/web-service.ts
+++ b/lib/web-service/web-service.ts
@@ -6,6 +6,7 @@ import {
   IngressTls,
   IntOrString,
   IoK8SApiCoreV1ContainerImagePullPolicy,
+  IoK8SApiCoreV1ContainerPortProtocol,
   IoK8SApiCoreV1ServicePortProtocol,
   IoK8SApiCoreV1ServiceSpecType,
   KubeDeployment,
@@ -71,7 +72,12 @@ export class WebService extends Construct {
         command: props.command,
         args: props.args,
         resources: props.resources,
-        ports: [{ containerPort: applicationPort, protocol: "TCP" }],
+        ports: [
+          {
+            containerPort: applicationPort,
+            protocol: IoK8SApiCoreV1ContainerPortProtocol.TCP,
+          },
+        ],
         securityContext: props.securityContext,
         env: props.env,
         envFrom: props.envFrom,
@@ -455,7 +461,12 @@ export class WebService extends Construct {
           memory: Quantity.fromString("128Mi"),
         },
       },
-      ports: [{ containerPort: nginxPort, protocol: "TCP" }],
+      ports: [
+        {
+          containerPort: nginxPort,
+          protocol: IoK8SApiCoreV1ContainerPortProtocol.TCP,
+        },
+      ],
       startupProbe: nginx.startupProbe,
       livenessProbe: nginx.livenessProbe ?? {
         failureThreshold: 3,

--- a/lib/web-service/web-service.ts
+++ b/lib/web-service/web-service.ts
@@ -5,6 +5,9 @@ import {
   IngressRule,
   IngressTls,
   IntOrString,
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  IoK8SApiCoreV1ServicePortProtocol,
+  IoK8SApiCoreV1ServiceSpecType,
   KubeDeployment,
   KubeHorizontalPodAutoscalerV2,
   KubeIngress,
@@ -61,7 +64,9 @@ export class WebService extends Construct {
       {
         name: props.containerName ?? app ?? "app",
         image: props.image,
-        imagePullPolicy: props.imagePullPolicy ?? "IfNotPresent",
+        imagePullPolicy:
+          props.imagePullPolicy ??
+          IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT,
         workingDir: props.workingDir,
         command: props.command,
         args: props.args,
@@ -133,12 +138,15 @@ export class WebService extends Construct {
           labels: instanceLabels,
         },
         spec: {
-          type: ingressTargetType === "instance" ? "NodePort" : "ClusterIP",
+          type:
+            ingressTargetType === "instance"
+              ? IoK8SApiCoreV1ServiceSpecType.NODE_PORT
+              : IoK8SApiCoreV1ServiceSpecType.CLUSTER_IP,
           ports: [
             {
               port: servicePort,
               targetPort: IntOrString.fromNumber(applicationPort),
-              protocol: "TCP",
+              protocol: IoK8SApiCoreV1ServicePortProtocol.TCP,
             },
           ],
           selector: serviceLabels,
@@ -435,7 +443,9 @@ export class WebService extends Construct {
     const container: Container = {
       name: "nginx",
       image: nginx.image ?? "public.ecr.aws/nginx/nginx:1.21.5",
-      imagePullPolicy: nginx.imagePullPolicy ?? "IfNotPresent",
+      imagePullPolicy:
+        nginx.imagePullPolicy ??
+        IoK8SApiCoreV1ContainerImagePullPolicy.IF_NOT_PRESENT,
       resources: nginx.resources ?? {
         requests: {
           cpu: Quantity.fromString("50m"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,42 +8,42 @@
       "name": "talis-cdk8s-constructs",
       "version": "0.1.0",
       "dependencies": {
-        "cron-parser": "4.6.0",
+        "cron-parser": "4.7.0",
         "dotenv": "^14.3.2",
         "sort-keys": "^4.2.0"
       },
       "devDependencies": {
-        "@commitlint/cli": "^17.2.0",
-        "@commitlint/config-conventional": "^17.2.0",
-        "@types/lodash": "^4.14.188",
+        "@commitlint/cli": "^17.3.0",
+        "@commitlint/config-conventional": "^17.3.0",
+        "@types/lodash": "^4.14.190",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^18.11.9",
-        "@typescript-eslint/eslint-plugin": "^5.42.1",
-        "@typescript-eslint/parser": "^5.42.1",
+        "@typescript-eslint/eslint-plugin": "^5.45.0",
+        "@typescript-eslint/parser": "^5.45.0",
         "bats": "^1.8.2",
         "c8": "^7.12.0",
-        "cdk8s": "^2.5.44",
-        "cdk8s-cli": "^2.1.46",
-        "constructs": "^10.1.159",
-        "eslint": "^8.27.0",
+        "cdk8s": "^2.5.60",
+        "cdk8s-cli": "^2.1.62",
+        "constructs": "^10.1.175",
+        "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "husky": "^8.0.2",
-        "lint-staged": "^13.0.3",
+        "lint-staged": "^13.0.4",
         "lodash": "^4.17.21",
         "mock-fs": "^5.2.0",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.0",
         "semantic-release": "^19.0.5",
         "ts-node": "^10.9.1",
-        "typescript": "^4.8.4",
-        "vitest": "^0.25.1"
+        "typescript": "^4.9.3",
+        "vitest": "^0.25.3"
       },
       "engines": {
         "node": ">=16.13.2",
         "npm": ">=8.1.2"
       },
       "peerDependencies": {
-        "cdk8s": "^2.5.44",
-        "constructs": "^10.1.159"
+        "cdk8s": "^2.5.60",
+        "constructs": "^10.1.175"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -159,18 +159,18 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.3.0.tgz",
+      "integrity": "sha512-/H0md7TsKflKzVPz226VfXzVafJFO1f9+r2KcFvmBu08V0T56lZU1s8WL7/xlxqLMqBTVaBf7Ixtc4bskdEEZg==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
+        "@commitlint/lint": "^17.3.0",
+        "@commitlint/load": "^17.3.0",
         "@commitlint/read": "^17.2.0",
         "@commitlint/types": "^17.0.0",
         "execa": "^5.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.3.0.tgz",
+      "integrity": "sha512-hgI+fN5xF8nhS9uG/V06xyT0nlcyvHHMkq0kwRSr96vl5BFlRGaL2C0/YY4kQagfU087tmj01bJkG9Ek98Wllw==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -208,13 +208,17 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.3.0.tgz",
+      "integrity": "sha512-kWbrQHDoW5veIUQx30gXoLOCjWvwC6OOEofhPCLl5ytRPBDAQObMbxTha1Bt2aSyNE/IrJ0s0xkdZ1Gi3wJwQg==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
       },
       "engines": {
         "node": ">=v14"
@@ -256,14 +260,14 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.3.0.tgz",
+      "integrity": "sha512-VilOTPg0i9A7CCWM49E9bl5jytfTvfTxf9iwbWAWNjxJ/A5mhPKbm3sHuAdwJ87tDk1k4j8vomYfH23iaY+1Rw==",
       "dev": true,
       "dependencies": {
         "@commitlint/is-ignored": "^17.2.0",
         "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
+        "@commitlint/rules": "^17.3.0",
         "@commitlint/types": "^17.0.0"
       },
       "engines": {
@@ -271,20 +275,22 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.3.0.tgz",
+      "integrity": "sha512-u/pV6rCAJrCUN+HylBHLzZ4qj1Ew3+eN9GBPhNi9otGxtOfA8b+8nJSxaNbcC23Ins/kcpjGf9zPSVW7628Umw==",
       "dev": true,
       "dependencies": {
         "@commitlint/config-validator": "^17.1.0",
         "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
+        "@commitlint/resolve-extends": "^17.3.0",
         "@commitlint/types": "^17.0.0",
         "@types/node": "^14.0.0",
         "chalk": "^4.1.0",
         "cosmiconfig": "^7.0.0",
         "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
         "resolve-from": "^5.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.4"
@@ -339,15 +345,15 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.3.0.tgz",
+      "integrity": "sha512-Lf3JufJlc5yVEtJWC8o4IAZaB8FQAUaVlhlAHRACd0TTFizV2Lk2VH70et23KgvbQNf7kQzHs/2B4QZalBv6Cg==",
       "dev": true,
       "dependencies": {
         "@commitlint/config-validator": "^17.1.0",
         "@commitlint/types": "^17.0.0",
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
@@ -356,12 +362,12 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.3.0.tgz",
+      "integrity": "sha512-s2UhDjC5yP2utx3WWqsnZRzjgzAX8BMwr1nltC0u0p8T/nzpkx4TojEfhlsOUj1t7efxzZRjUAV0NxNwdJyk+g==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^17.0.0",
+        "@commitlint/ensure": "^17.3.0",
         "@commitlint/message": "^17.2.0",
         "@commitlint/to-lines": "^17.0.0",
         "@commitlint/types": "^17.0.0",
@@ -969,9 +975,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.188",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
-      "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
+      "version": "4.14.190",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+      "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
     "node_modules/@types/minimist": {
@@ -1020,14 +1026,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.0.tgz",
+      "integrity": "sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/type-utils": "5.45.0",
+        "@typescript-eslint/utils": "5.45.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -1053,14 +1059,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.0.tgz",
+      "integrity": "sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1080,13 +1086,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz",
+      "integrity": "sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1097,13 +1103,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.0.tgz",
+      "integrity": "sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.45.0",
+        "@typescript-eslint/utils": "5.45.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1124,9 +1130,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.0.tgz",
+      "integrity": "sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1137,13 +1143,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.0.tgz",
+      "integrity": "sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1164,16 +1170,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.0.tgz",
+      "integrity": "sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -1190,12 +1196,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz",
+      "integrity": "sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.45.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1575,9 +1581,9 @@
       }
     },
     "node_modules/cdk8s": {
-      "version": "2.5.44",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.44.tgz",
-      "integrity": "sha512-BaXBQHlQWb0jgrE8y6zJhjsfxvhWQd/q3OLxiD4AHfU2y5OxrW8Fq+s++9wYRkYdKu3RVA303dqO0vFkgMQD8Q==",
+      "version": "2.5.60",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.60.tgz",
+      "integrity": "sha512-qU1tzJLI4ozpQfHhqm/iy/58hyUGnXucUVrBLqMDTTQhMfw4G1n55j4xqz/RQAI5fPBBNu4g7w9fjOI6Ed0wjw==",
       "bundleDependencies": [
         "fast-json-patch",
         "follow-redirects",
@@ -1597,22 +1603,22 @@
       }
     },
     "node_modules/cdk8s-cli": {
-      "version": "2.1.46",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.46.tgz",
-      "integrity": "sha512-cfFjjyY6R2Eo3uuerdRG1alCdxnBEg9LcywlEgNPXrl6OtmzNYGJuNToe/8rnsLd/+BmQB6SqGkuzeKK0LV6UQ==",
+      "version": "2.1.62",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.62.tgz",
+      "integrity": "sha512-H6yAU2X4jX2MCmoCNnK2dDPMhGo3DCICmILifnVFgRP75nASq45A2jijl8RxAM1KhjLyf2Io5RFhOVEm4XvGeQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "^14",
         "ajv": "^8.11.2",
-        "cdk8s": "^2.5.44",
-        "cdk8s-plus-25": "^2.0.25",
+        "cdk8s": "^2.5.60",
+        "cdk8s-plus-25": "^2.0.44",
         "codemaker": "^1.71.0",
         "colors": "1.4.0",
-        "constructs": "^10.1.159",
+        "constructs": "^10.1.175",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.71.0",
-        "jsii-srcmak": "^0.1.733",
-        "json2jsii": "^0.3.182",
+        "jsii-srcmak": "^0.1.748",
+        "json2jsii": "^0.3.198",
         "semver": "^7.3.8",
         "sscaff": "^1.2.274",
         "table": "^6.8.1",
@@ -1816,9 +1822,9 @@
       }
     },
     "node_modules/cdk8s-plus-25": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.26.tgz",
-      "integrity": "sha512-CV+Z63yu/9kr3u+9k4QRdmpnqe+gAera7RWWkhwONnJj9QQxKR/+z4hx3yPOjZ5Y2EdhTjyk3Kba3Cr8vcrBKA==",
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.45.tgz",
+      "integrity": "sha512-PHOJ0g46AibzLZzLzjs4tY/+XJvoDA2reNe6njg4F2Pi/cnLlLTpWFEWUSuutPq6wJK7T7j/wTjKXVNYEVJzPg==",
       "bundleDependencies": [
         "minimatch"
       ],
@@ -1830,8 +1836,8 @@
         "node": ">= 14.17.0"
       },
       "peerDependencies": {
-        "cdk8s": "^2.5.44",
-        "constructs": "^10.1.159"
+        "cdk8s": "^2.5.60",
+        "constructs": "^10.1.175"
       }
     },
     "node_modules/cdk8s-plus-25/node_modules/balanced-match": {
@@ -2116,9 +2122,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -2159,9 +2165,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.159",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.159.tgz",
-      "integrity": "sha512-MXr+VXrNnyztGt06Y9reFd+m8vI0S/5/ogtgGQRCiwlz2XUjyTE02FuV4vYxSV8p1B2GY0DN9dubK/7DH5O3PQ==",
+      "version": "10.1.175",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.175.tgz",
+      "integrity": "sha512-SL7ywhJ3QvkjrSX2aespKUmyRYCyC1qHEJnqouUsrMl60Ne4BGNqskE9oyaLeizpsMC2qyEEx9OwDYPclKd8Vg==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -2322,11 +2328,11 @@
       "dev": true
     },
     "node_modules/cron-parser": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
-      "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.0.tgz",
+      "integrity": "sha512-BdAELR+MCT2ZWsIBhZKDuUqIUCBjHHulPJnm53OfdRLA4EWBjva3R+KM5NeidJuGsNXdEcZkjC7SCnkW5rAFSA==",
       "dependencies": {
-        "luxon": "^3.0.1"
+        "luxon": "^3.1.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3052,9 +3058,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
@@ -4425,9 +4431,9 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.733",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.733.tgz",
-      "integrity": "sha512-QZ5KKv4Uay0Exg0ZSrssli4lrEH2XujygYImTN4WAJBhgPnyc7QM/wFuX5yzRQrNRgDy+CCkBuK8xybNEQft7Q==",
+      "version": "0.1.748",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.748.tgz",
+      "integrity": "sha512-tdE07G7opE+mtPnugQ5HK6rhjy0skj1dHn7Nh/cT0iEswCoFodml+FTB3/DkYlKoRH80gGgTKbdrKV38gWiv4A==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
@@ -4674,9 +4680,9 @@
       "dev": true
     },
     "node_modules/json2jsii": {
-      "version": "0.3.182",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.182.tgz",
-      "integrity": "sha512-31paTn+V9PUGEha/xv4urvw/Xpr59pkrpugDeRVdqFLzknhxTOhcH2IRfb+wKHMG5LZjj58br1Qitg2nP4ynEg==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.198.tgz",
+      "integrity": "sha512-lTDzJX0WsDTHD3unMG68pwDix8Gdg42qBcex4B2E29UqJ0BMLrHTz1wKrwWD01Hnecl/uwTaVQDC//WPVaaOVw==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -4747,9 +4753,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -4762,24 +4768,24 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+      "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^3.1.0",
-        "colorette": "^2.0.17",
-        "commander": "^9.3.0",
+        "colorette": "^2.0.19",
+        "commander": "^9.4.1",
         "debug": "^4.3.4",
         "execa": "^6.1.0",
-        "lilconfig": "2.0.5",
-        "listr2": "^4.0.5",
+        "lilconfig": "2.0.6",
+        "listr2": "^5.0.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-inspect": "^1.12.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.1",
-        "yaml": "^2.1.1"
+        "yaml": "^2.1.3"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -4902,31 +4908,31 @@
       }
     },
     "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/listr2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
+      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
+        "colorette": "^2.0.19",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.5",
+        "rxjs": "^7.5.7",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
         "enquirer": ">= 2.3.0 < 3"
@@ -5052,6 +5058,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -5062,6 +5074,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "dev": true
     },
     "node_modules/lodash.ismatch": {
@@ -5082,10 +5100,34 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true
     },
     "node_modules/lodash.truncate": {
@@ -5094,10 +5136,22 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true
+    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "node_modules/log-update": {
@@ -5150,9 +5204,9 @@
       }
     },
     "node_modules/log4js": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
-      "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.1.tgz",
+      "integrity": "sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==",
       "dev": true,
       "dependencies": {
         "date-format": "^4.0.14",
@@ -5196,9 +5250,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.1.tgz",
+      "integrity": "sha512-Ah6DloGmvseB/pX1cAmjbFvyU/pKuwQMQqz7d0yvuDlVYLTs2WeDHQMpC8tGjm1da+BriHROW/OEIT/KfYg6xw==",
       "engines": {
         "node": ">=12"
       }
@@ -8526,9 +8580,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8961,9 +9015,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -9874,9 +9928,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -9934,9 +9988,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10079,9 +10133,9 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.1.tgz",
-      "integrity": "sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.3.tgz",
+      "integrity": "sha512-/UzHfXIKsELZhL7OaM2xFlRF8HRZgAHtPctacvNK8H4vOcbJJAMEgbWNGSAK7Y9b1NBe5SeM7VTuz2RsTHFJJA==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.3",
@@ -10390,27 +10444,27 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.3.0.tgz",
+      "integrity": "sha512-/H0md7TsKflKzVPz226VfXzVafJFO1f9+r2KcFvmBu08V0T56lZU1s8WL7/xlxqLMqBTVaBf7Ixtc4bskdEEZg==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
+        "@commitlint/lint": "^17.3.0",
+        "@commitlint/load": "^17.3.0",
         "@commitlint/read": "^17.2.0",
         "@commitlint/types": "^17.0.0",
         "execa": "^5.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.3.0.tgz",
+      "integrity": "sha512-hgI+fN5xF8nhS9uG/V06xyT0nlcyvHHMkq0kwRSr96vl5BFlRGaL2C0/YY4kQagfU087tmj01bJkG9Ek98Wllw==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -10427,13 +10481,17 @@
       }
     },
     "@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.3.0.tgz",
+      "integrity": "sha512-kWbrQHDoW5veIUQx30gXoLOCjWvwC6OOEofhPCLl5ytRPBDAQObMbxTha1Bt2aSyNE/IrJ0s0xkdZ1Gi3wJwQg==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -10463,32 +10521,34 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.3.0.tgz",
+      "integrity": "sha512-VilOTPg0i9A7CCWM49E9bl5jytfTvfTxf9iwbWAWNjxJ/A5mhPKbm3sHuAdwJ87tDk1k4j8vomYfH23iaY+1Rw==",
       "dev": true,
       "requires": {
         "@commitlint/is-ignored": "^17.2.0",
         "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
+        "@commitlint/rules": "^17.3.0",
         "@commitlint/types": "^17.0.0"
       }
     },
     "@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.3.0.tgz",
+      "integrity": "sha512-u/pV6rCAJrCUN+HylBHLzZ4qj1Ew3+eN9GBPhNi9otGxtOfA8b+8nJSxaNbcC23Ins/kcpjGf9zPSVW7628Umw==",
       "dev": true,
       "requires": {
         "@commitlint/config-validator": "^17.1.0",
         "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
+        "@commitlint/resolve-extends": "^17.3.0",
         "@commitlint/types": "^17.0.0",
         "@types/node": "^14.0.0",
         "chalk": "^4.1.0",
         "cosmiconfig": "^7.0.0",
         "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
         "resolve-from": "^5.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.4"
@@ -10533,26 +10593,26 @@
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.3.0.tgz",
+      "integrity": "sha512-Lf3JufJlc5yVEtJWC8o4IAZaB8FQAUaVlhlAHRACd0TTFizV2Lk2VH70et23KgvbQNf7kQzHs/2B4QZalBv6Cg==",
       "dev": true,
       "requires": {
         "@commitlint/config-validator": "^17.1.0",
         "@commitlint/types": "^17.0.0",
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       }
     },
     "@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.3.0.tgz",
+      "integrity": "sha512-s2UhDjC5yP2utx3WWqsnZRzjgzAX8BMwr1nltC0u0p8T/nzpkx4TojEfhlsOUj1t7efxzZRjUAV0NxNwdJyk+g==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^17.0.0",
+        "@commitlint/ensure": "^17.3.0",
         "@commitlint/message": "^17.2.0",
         "@commitlint/to-lines": "^17.0.0",
         "@commitlint/types": "^17.0.0",
@@ -11047,9 +11107,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.188",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
-      "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
+      "version": "4.14.190",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+      "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
       "dev": true
     },
     "@types/minimist": {
@@ -11098,14 +11158,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.0.tgz",
+      "integrity": "sha512-CXXHNlf0oL+Yg021cxgOdMHNTXD17rHkq7iW6RFHoybdFgQBjU3yIXhhcPpGwr1CjZlo6ET8C6tzX5juQoXeGA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/type-utils": "5.45.0",
+        "@typescript-eslint/utils": "5.45.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -11115,53 +11175,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.0.tgz",
+      "integrity": "sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz",
+      "integrity": "sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.45.0.tgz",
+      "integrity": "sha512-DY7BXVFSIGRGFZ574hTEyLPRiQIvI/9oGcN8t1A7f6zIs6ftbrU0nhyV26ZW//6f85avkwrLag424n+fkuoJ1Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.45.0",
+        "@typescript-eslint/utils": "5.45.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.0.tgz",
+      "integrity": "sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.0.tgz",
+      "integrity": "sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -11170,28 +11230,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.0.tgz",
+      "integrity": "sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz",
+      "integrity": "sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.45.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11471,9 +11531,9 @@
       "dev": true
     },
     "cdk8s": {
-      "version": "2.5.44",
-      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.44.tgz",
-      "integrity": "sha512-BaXBQHlQWb0jgrE8y6zJhjsfxvhWQd/q3OLxiD4AHfU2y5OxrW8Fq+s++9wYRkYdKu3RVA303dqO0vFkgMQD8Q==",
+      "version": "2.5.60",
+      "resolved": "https://registry.npmjs.org/cdk8s/-/cdk8s-2.5.60.tgz",
+      "integrity": "sha512-qU1tzJLI4ozpQfHhqm/iy/58hyUGnXucUVrBLqMDTTQhMfw4G1n55j4xqz/RQAI5fPBBNu4g7w9fjOI6Ed0wjw==",
       "dev": true,
       "requires": {
         "fast-json-patch": "^3.1.1",
@@ -11499,22 +11559,22 @@
       }
     },
     "cdk8s-cli": {
-      "version": "2.1.46",
-      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.46.tgz",
-      "integrity": "sha512-cfFjjyY6R2Eo3uuerdRG1alCdxnBEg9LcywlEgNPXrl6OtmzNYGJuNToe/8rnsLd/+BmQB6SqGkuzeKK0LV6UQ==",
+      "version": "2.1.62",
+      "resolved": "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.62.tgz",
+      "integrity": "sha512-H6yAU2X4jX2MCmoCNnK2dDPMhGo3DCICmILifnVFgRP75nASq45A2jijl8RxAM1KhjLyf2Io5RFhOVEm4XvGeQ==",
       "dev": true,
       "requires": {
         "@types/node": "^14",
         "ajv": "^8.11.2",
-        "cdk8s": "^2.5.44",
-        "cdk8s-plus-25": "^2.0.25",
+        "cdk8s": "^2.5.60",
+        "cdk8s-plus-25": "^2.0.44",
         "codemaker": "^1.71.0",
         "colors": "1.4.0",
-        "constructs": "^10.1.159",
+        "constructs": "^10.1.175",
         "fs-extra": "^8",
         "jsii-pacmak": "^1.71.0",
-        "jsii-srcmak": "^0.1.733",
-        "json2jsii": "^0.3.182",
+        "jsii-srcmak": "^0.1.748",
+        "json2jsii": "^0.3.198",
         "semver": "^7.3.8",
         "sscaff": "^1.2.274",
         "table": "^6.8.1",
@@ -11672,9 +11732,9 @@
       }
     },
     "cdk8s-plus-25": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.26.tgz",
-      "integrity": "sha512-CV+Z63yu/9kr3u+9k4QRdmpnqe+gAera7RWWkhwONnJj9QQxKR/+z4hx3yPOjZ5Y2EdhTjyk3Kba3Cr8vcrBKA==",
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/cdk8s-plus-25/-/cdk8s-plus-25-2.0.45.tgz",
+      "integrity": "sha512-PHOJ0g46AibzLZzLzjs4tY/+XJvoDA2reNe6njg4F2Pi/cnLlLTpWFEWUSuutPq6wJK7T7j/wTjKXVNYEVJzPg==",
       "dev": true,
       "requires": {
         "minimatch": "^3.1.2"
@@ -11865,9 +11925,9 @@
       "dev": true
     },
     "commander": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true
     },
     "commonmark": {
@@ -11899,9 +11959,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.159",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.159.tgz",
-      "integrity": "sha512-MXr+VXrNnyztGt06Y9reFd+m8vI0S/5/ogtgGQRCiwlz2XUjyTE02FuV4vYxSV8p1B2GY0DN9dubK/7DH5O3PQ==",
+      "version": "10.1.175",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.175.tgz",
+      "integrity": "sha512-SL7ywhJ3QvkjrSX2aespKUmyRYCyC1qHEJnqouUsrMl60Ne4BGNqskE9oyaLeizpsMC2qyEEx9OwDYPclKd8Vg==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -12024,11 +12084,11 @@
       "dev": true
     },
     "cron-parser": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.6.0.tgz",
-      "integrity": "sha512-guZNLMGUgg6z4+eGhmHGw7ft+v6OQeuHzd1gcLxCo9Yg/qoxmG3nindp2/uwGCLizEisf2H0ptqeVXeoCpP6FA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.0.tgz",
+      "integrity": "sha512-BdAELR+MCT2ZWsIBhZKDuUqIUCBjHHulPJnm53OfdRLA4EWBjva3R+KM5NeidJuGsNXdEcZkjC7SCnkW5rAFSA==",
       "requires": {
-        "luxon": "^3.0.1"
+        "luxon": "^3.1.0"
       }
     },
     "cross-spawn": {
@@ -12481,9 +12541,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
@@ -13549,9 +13609,9 @@
       }
     },
     "jsii-srcmak": {
-      "version": "0.1.733",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.733.tgz",
-      "integrity": "sha512-QZ5KKv4Uay0Exg0ZSrssli4lrEH2XujygYImTN4WAJBhgPnyc7QM/wFuX5yzRQrNRgDy+CCkBuK8xybNEQft7Q==",
+      "version": "0.1.748",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.748.tgz",
+      "integrity": "sha512-tdE07G7opE+mtPnugQ5HK6rhjy0skj1dHn7Nh/cT0iEswCoFodml+FTB3/DkYlKoRH80gGgTKbdrKV38gWiv4A==",
       "dev": true,
       "requires": {
         "fs-extra": "^9.1.0",
@@ -13718,9 +13778,9 @@
       "dev": true
     },
     "json2jsii": {
-      "version": "0.3.182",
-      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.182.tgz",
-      "integrity": "sha512-31paTn+V9PUGEha/xv4urvw/Xpr59pkrpugDeRVdqFLzknhxTOhcH2IRfb+wKHMG5LZjj58br1Qitg2nP4ynEg==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/json2jsii/-/json2jsii-0.3.198.tgz",
+      "integrity": "sha512-lTDzJX0WsDTHD3unMG68pwDix8Gdg42qBcex4B2E29UqJ0BMLrHTz1wKrwWD01Hnecl/uwTaVQDC//WPVaaOVw==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -13771,9 +13831,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
     "lines-and-columns": {
@@ -13783,24 +13843,24 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+      "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
-        "colorette": "^2.0.17",
-        "commander": "^9.3.0",
+        "colorette": "^2.0.19",
+        "commander": "^9.4.1",
         "debug": "^4.3.4",
         "execa": "^6.1.0",
-        "lilconfig": "2.0.5",
-        "listr2": "^4.0.5",
+        "lilconfig": "2.0.6",
+        "listr2": "^5.0.5",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-inspect": "^1.12.2",
         "pidtree": "^0.6.0",
         "string-argv": "^0.3.1",
-        "yaml": "^2.1.1"
+        "yaml": "^2.1.3"
       },
       "dependencies": {
         "execa": {
@@ -13869,25 +13929,25 @@
           "dev": true
         },
         "yaml": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+          "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
           "dev": true
         }
       }
     },
     "listr2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
+      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
+        "colorette": "^2.0.19",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.5",
+        "rxjs": "^7.5.7",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -13975,6 +14035,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -13985,6 +14051,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -14005,10 +14077,34 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true
     },
     "lodash.truncate": {
@@ -14017,10 +14113,22 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true
+    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "log-update": {
@@ -14060,9 +14168,9 @@
       }
     },
     "log4js": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
-      "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.1.tgz",
+      "integrity": "sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==",
       "dev": true,
       "requires": {
         "date-format": "^4.0.14",
@@ -14100,9 +14208,9 @@
       }
     },
     "luxon": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.1.tgz",
+      "integrity": "sha512-Ah6DloGmvseB/pX1cAmjbFvyU/pKuwQMQqz7d0yvuDlVYLTs2WeDHQMpC8tGjm1da+BriHROW/OEIT/KfYg6xw=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -16443,9 +16551,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true
     },
     "process-nextick-args": {
@@ -16743,9 +16851,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -17447,9 +17555,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tsutils": {
@@ -17491,9 +17599,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "uglify-js": {
@@ -17586,9 +17694,9 @@
       }
     },
     "vitest": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.1.tgz",
-      "integrity": "sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.3.tgz",
+      "integrity": "sha512-/UzHfXIKsELZhL7OaM2xFlRF8HRZgAHtPctacvNK8H4vOcbJJAMEgbWNGSAK7Y9b1NBe5SeM7VTuz2RsTHFJJA==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -32,37 +32,37 @@
     "coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "cdk8s": "^2.5.44",
-    "constructs": "^10.1.159"
+    "cdk8s": "^2.5.60",
+    "constructs": "^10.1.175"
   },
   "dependencies": {
-    "cron-parser": "4.6.0",
+    "cron-parser": "4.7.0",
     "dotenv": "^14.3.2",
     "sort-keys": "^4.2.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.2.0",
-    "@commitlint/config-conventional": "^17.2.0",
-    "@types/lodash": "^4.14.188",
+    "@commitlint/cli": "^17.3.0",
+    "@commitlint/config-conventional": "^17.3.0",
+    "@types/lodash": "^4.14.190",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^18.11.9",
-    "@typescript-eslint/eslint-plugin": "^5.42.1",
-    "@typescript-eslint/parser": "^5.42.1",
+    "@typescript-eslint/eslint-plugin": "^5.45.0",
+    "@typescript-eslint/parser": "^5.45.0",
     "bats": "^1.8.2",
     "c8": "^7.12.0",
-    "cdk8s": "^2.5.44",
-    "cdk8s-cli": "^2.1.46",
-    "constructs": "^10.1.159",
-    "eslint": "^8.27.0",
+    "cdk8s": "^2.5.60",
+    "cdk8s-cli": "^2.1.62",
+    "constructs": "^10.1.175",
+    "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^8.0.2",
-    "lint-staged": "^13.0.3",
+    "lint-staged": "^13.0.4",
     "lodash": "^4.17.21",
     "mock-fs": "^5.2.0",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.0",
     "semantic-release": "^19.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4",
-    "vitest": "^0.25.1"
+    "typescript": "^4.9.3",
+    "vitest": "^0.25.3"
   }
 }

--- a/test/background-worker/background-worker.test.ts
+++ b/test/background-worker/background-worker.test.ts
@@ -1,5 +1,9 @@
 import { Chart, Testing } from "cdk8s";
-import { Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  Quantity,
+} from "../../imports/k8s";
 import { BackgroundWorker, BackgroundWorkerProps } from "../../lib";
 
 const requiredProps = {
@@ -55,11 +59,11 @@ describe("BackgroundWorker", () => {
         env: [{ name: "FOO", value: "bar" }],
         envFrom: [{ configMapRef: { name: "foo-config" } }],
         automountServiceAccountToken: true,
-        imagePullPolicy: "Always",
+        imagePullPolicy: IoK8SApiCoreV1ContainerImagePullPolicy.ALWAYS,
         imagePullSecrets: [{ name: "foo-secret" }],
         priorityClassName: "high-priority",
         revisionHistoryLimit: 5,
-        restartPolicy: "Always",
+        restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.ALWAYS,
         affinity: {
           podAntiAffinity: {
             preferredDuringSchedulingIgnoredDuringExecution: [

--- a/test/cron-job/cron-job.test.ts
+++ b/test/cron-job/cron-job.test.ts
@@ -1,5 +1,9 @@
 import { Chart, Testing } from "cdk8s";
-import { Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  Quantity,
+} from "../../imports/k8s";
 import { CronJob, CronJobProps } from "../../lib";
 import { makeChart } from "../test-util";
 
@@ -14,7 +18,7 @@ const requiredProps: CronJobProps = {
     },
   },
   backoffLimit: 2,
-  restartPolicy: "OnFailure",
+  restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.ON_FAILURE,
 };
 
 function synthCronJob(
@@ -65,7 +69,7 @@ describe("CronJob", () => {
         backoffLimit: 1,
         env: [{ name: "FOO", value: "bar" }],
         envFrom: [{ configMapRef: { name: "foo-config" } }],
-        imagePullPolicy: "Always",
+        imagePullPolicy: IoK8SApiCoreV1ContainerImagePullPolicy.ALWAYS,
         imagePullSecrets: [{ name: "foo-secret" }],
         startingDeadlineSeconds: 200,
         successfulJobsHistoryLimit: 4,
@@ -132,7 +136,7 @@ describe("CronJob", () => {
     test("Setting restartPolicy", () => {
       const results = synthCronJob({
         ...requiredProps,
-        restartPolicy: "Never",
+        restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
       });
       const cron = results.find((obj) => obj.kind === "CronJob");
       expect(cron).toHaveProperty(

--- a/test/job/job.test.ts
+++ b/test/job/job.test.ts
@@ -1,5 +1,9 @@
 import { Chart, Testing } from "cdk8s";
-import { Quantity } from "../../imports/k8s";
+import {
+  IoK8SApiCoreV1ContainerImagePullPolicy,
+  IoK8SApiCoreV1PodSpecRestartPolicy,
+  Quantity,
+} from "../../imports/k8s";
 import { Job, JobProps } from "../../lib";
 import { makeChart } from "../test-util";
 
@@ -13,7 +17,7 @@ const requiredProps: JobProps = {
     },
   },
   backoffLimit: 0,
-  restartPolicy: "Never",
+  restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
 };
 
 function synthJob(
@@ -64,7 +68,7 @@ describe("Job", () => {
         ttlSecondsAfterFinished: 30,
         env: [{ name: "FOO", value: "bar" }],
         envFrom: [{ configMapRef: { name: "foo-config" } }],
-        imagePullPolicy: "Always",
+        imagePullPolicy: IoK8SApiCoreV1ContainerImagePullPolicy.ALWAYS,
         imagePullSecrets: [{ name: "foo-secret" }],
         resources: {
           requests: {
@@ -128,7 +132,7 @@ describe("Job", () => {
     test("Setting restartPolicy", () => {
       const results = synthJob({
         ...requiredProps,
-        restartPolicy: "Never",
+        restartPolicy: IoK8SApiCoreV1PodSpecRestartPolicy.NEVER,
       });
       const job = results.find((obj) => obj.kind === "Job");
       expect(job).toHaveProperty("spec.template.spec.restartPolicy", "Never");

--- a/test/talis-chart/talis-chart.test.ts
+++ b/test/talis-chart/talis-chart.test.ts
@@ -2,6 +2,7 @@ import { ApiObject, Testing } from "cdk8s";
 import {
   DeploymentSpec,
   IntOrString,
+  IoK8SApiAppsV1DeploymentStrategyType,
   KubeCronJob,
   KubeDaemonSet,
   KubeDeployment,
@@ -424,7 +425,7 @@ describe("TalisChart", () => {
       makeDeployment(chart, "my-deploy", {
         replicas: 3,
         strategy: {
-          type: "RollingUpdate",
+          type: IoK8SApiAppsV1DeploymentStrategyType.ROLLING_UPDATE,
           rollingUpdate: {
             maxSurge: IntOrString.fromNumber(2),
           },
@@ -447,7 +448,7 @@ describe("TalisChart", () => {
       makeDeployment(chart, "my-deploy", {
         replicas: 3,
         strategy: {
-          type: "RollingUpdate",
+          type: IoK8SApiAppsV1DeploymentStrategyType.ROLLING_UPDATE,
           rollingUpdate: {
             maxSurge: IntOrString.fromString("90%"),
           },

--- a/test/talis-chart/talis-chart.test.ts
+++ b/test/talis-chart/talis-chart.test.ts
@@ -1,17 +1,17 @@
 import { ApiObject, Testing } from "cdk8s";
 import {
-  KubeDeployment,
-  KubePod,
-  Quantity,
   DeploymentSpec,
-  KubeHorizontalPodAutoscalerV2Beta2,
   IntOrString,
-  ResourceRequirements,
-  PodSpec,
-  KubeDaemonSet,
-  KubeStatefulSet,
-  KubeJob,
   KubeCronJob,
+  KubeDaemonSet,
+  KubeDeployment,
+  KubeHorizontalPodAutoscalerV2,
+  KubeJob,
+  KubePod,
+  KubeStatefulSet,
+  PodSpec,
+  Quantity,
+  ResourceRequirements,
 } from "../../imports/k8s";
 import {
   TalisChart,
@@ -468,7 +468,7 @@ describe("TalisChart", () => {
       const app = Testing.app();
       const chart = new TalisChart(app, defaultProps);
       const deployment = makeDeployment(chart);
-      new KubeHorizontalPodAutoscalerV2Beta2(chart, "hpa", {
+      new KubeHorizontalPodAutoscalerV2(chart, "hpa", {
         spec: {
           scaleTargetRef: {
             apiVersion: deployment.apiVersion,

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -463,7 +463,7 @@ exports[`WebService > Props > All the props 1`] = `
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {
@@ -1074,7 +1074,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler 1`] = `
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {
@@ -1277,7 +1277,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for both memory and cpu 
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {
@@ -1490,7 +1490,7 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for memory 1`] = `
     },
   },
   {
-    "apiVersion": "autoscaling/v2beta2",
+    "apiVersion": "autoscaling/v2",
     "kind": "HorizontalPodAutoscaler",
     "metadata": {
       "labels": {

--- a/test/web-service/web-service.test.ts
+++ b/test/web-service/web-service.test.ts
@@ -1,6 +1,7 @@
 import { Chart, Testing } from "cdk8s";
 import {
   IntOrString,
+  IoK8SApiCoreV1ContainerImagePullPolicy,
   KubeConfigMap,
   KubeDeployment,
   KubeIngress,
@@ -104,7 +105,7 @@ describe("WebService", () => {
         env: [{ name: "FOO", value: "bar" }],
         envFrom: [{ configMapRef: { name: "foo-config" } }],
         automountServiceAccountToken: true,
-        imagePullPolicy: "Always",
+        imagePullPolicy: IoK8SApiCoreV1ContainerImagePullPolicy.ALWAYS,
         imagePullSecrets: [{ name: "foo-secret" }],
         priorityClassName: "high-priority",
         revisionHistoryLimit: 5,
@@ -155,7 +156,7 @@ describe("WebService", () => {
         port: 3000,
         nginx: {
           image: "ubuntu/nginx:1.18-21.10_edge",
-          imagePullPolicy: "Always",
+          imagePullPolicy: IoK8SApiCoreV1ContainerImagePullPolicy.ALWAYS,
           configMap: "nginx-config",
           port: 80,
         },


### PR DESCRIPTION
* References https://github.com/talis/platform/issues/5989
* Update Kubernetes schema import to 1.23.
* Update settings to use enums - previously import would allow strings, now enums are provided.
* Update HorizontalPodAutoscaler from v2beta2 to v2.