### PR TITLE
feat: expose mongo service on internal nlb

### DIFF
--- a/examples/mongo/__snapshots__/chart.test.ts.snap
+++ b/examples/mongo/__snapshots__/chart.test.ts.snap
@@ -69,6 +69,7 @@ exports[`Mongo example > Snapshot 1`] = `
         "instance": "redis-example",
         "role": "mongo",
       },
+      "type": "ClusterIP",
     },
   },
   {

--- a/lib/mongo/mongo-props.ts
+++ b/lib/mongo/mongo-props.ts
@@ -39,4 +39,10 @@ export interface MongoProps {
    * @default "database"
    */
   readonly priorityClassName?: string;
+
+  /**
+   * Create an internal NLB for the service.
+   * @default false
+   */
+  readonly exposeService?: boolean;
 }

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -6,6 +6,11 @@ exports[`Mongo > Props > All the props 1`] = `
     "apiVersion": "v1",
     "kind": "Service",
     "metadata": {
+      "annotations": {
+        "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+        "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
+        "service.beta.kubernetes.io/load-balancer-source-ranges": "0.0.0.0/0",
+      },
       "labels": {
         "app": "my-app",
         "environment": "test",
@@ -18,7 +23,7 @@ exports[`Mongo > Props > All the props 1`] = `
       "namespace": "test",
     },
     "spec": {
-      "clusterIP": "None",
+      "loadBalancerClass": "service.k8s.aws/nlb",
       "ports": [
         {
           "port": 27017,
@@ -30,6 +35,7 @@ exports[`Mongo > Props > All the props 1`] = `
         "instance": "test",
         "role": "mongo",
       },
+      "type": "LoadBalancer",
     },
   },
   {
@@ -167,6 +173,7 @@ exports[`Mongo > Props > Minimal required props 1`] = `
         "instance": "mongo-test",
         "role": "mongo",
       },
+      "type": "ClusterIP",
     },
   },
   {

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -51,6 +51,7 @@ describe("Mongo", () => {
           },
         },
         priorityClassName: "test",
+        exposeService: true,
       };
       new Mongo(chart, "mongo-test", allProps);
       const results = Testing.synth(chart);
@@ -63,7 +64,23 @@ describe("Mongo", () => {
         "storageEngine",
         "storageSize",
         "resources",
+        "exposeService",
       ]);
+
+      const loadBalancer = results.find((obj) => obj.kind === "Service");
+      expect(loadBalancer).toHaveProperty("metadata.annotations");
+      expect(loadBalancer.metadata.annotations).toHaveProperty(
+        "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type",
+        "instance"
+      );
+      expect(loadBalancer.metadata.annotations).toHaveProperty(
+        "service.beta.kubernetes.io/load-balancer-source-ranges",
+        "0.0.0.0/0"
+      );
+      expect(loadBalancer.metadata.annotations).toHaveProperty(
+        "service.beta.kubernetes.io/aws-load-balancer-scheme",
+        "internal"
+      );
     });
 
     test("selectorLabels can override app", () => {


### PR DESCRIPTION
https://github.com/talis/platform/issues/5939

Update the mongo construct to have optional parameter to expose the mongo service on an internal nlb allowing all internal traffic.