### PR TITLE
feat!: add PodDisruptionBudget to WebService

### DIFF
--- a/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
+++ b/examples/advanced-web-service/__snapshots__/chart.test.ts.snap
@@ -305,6 +305,35 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     },
   },
   {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "advanced",
+        "canary": "false",
+        "environment": "development",
+        "instance": "web",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "role": "server",
+        "service": "advanced-development-local",
+      },
+      "name": "web-pdb",
+      "namespace": "advanced-test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "advanced",
+          "canary": "false",
+          "instance": "web",
+          "role": "server",
+        },
+      },
+    },
+  },
+  {
     "apiVersion": "v1",
     "kind": "Service",
     "metadata": {
@@ -1129,6 +1158,35 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     },
   },
   {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "advanced",
+        "canary": "false",
+        "environment": "development",
+        "instance": "web",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "role": "server",
+        "service": "advanced-development-local",
+      },
+      "name": "web-pdb",
+      "namespace": "advanced-test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "advanced",
+          "canary": "false",
+          "instance": "web",
+          "role": "server",
+        },
+      },
+    },
+  },
+  {
     "apiVersion": "v1",
     "kind": "Service",
     "metadata": {
@@ -1730,6 +1788,35 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
           ],
         },
       ],
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "advanced",
+        "canary": "false",
+        "environment": "development",
+        "instance": "web",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "role": "server",
+        "service": "advanced-development-local",
+      },
+      "name": "web-pdb",
+      "namespace": "advanced-test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "advanced",
+          "canary": "false",
+          "instance": "web",
+          "role": "server",
+        },
+      },
     },
   },
   {
@@ -2556,6 +2643,35 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
     },
   },
   {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "advanced",
+        "canary": "false",
+        "environment": "development",
+        "instance": "web",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "role": "server",
+        "service": "advanced-development-local",
+      },
+      "name": "web-pdb",
+      "namespace": "advanced-test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "advanced",
+          "canary": "false",
+          "instance": "web",
+          "role": "server",
+        },
+      },
+    },
+  },
+  {
     "apiVersion": "v1",
     "kind": "Service",
     "metadata": {
@@ -3156,6 +3272,35 @@ proxy_cookie_path / \\"/$cookie_path_patches\\";
           ],
         },
       ],
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "advanced",
+        "canary": "false",
+        "environment": "development",
+        "instance": "web",
+        "managed-by": "cdk8s",
+        "region": "local",
+        "role": "server",
+        "service": "advanced-development-local",
+      },
+      "name": "web-pdb",
+      "namespace": "advanced-test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "advanced",
+          "canary": "false",
+          "instance": "web",
+          "role": "server",
+        },
+      },
     },
   },
   {

--- a/examples/simple-web-service/__snapshots__/main.test.ts.snap
+++ b/examples/simple-web-service/__snapshots__/main.test.ts.snap
@@ -173,5 +173,25 @@ exports[`Simple WebService example > Snapshot 1`] = `
       },
     },
   },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "instance": "web",
+        "role": "server",
+      },
+      "name": "test-web-web-pdb-c86ae522",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "instance": "web",
+          "role": "server",
+        },
+      },
+    },
+  },
 ]
 `;

--- a/lib/common/value-util.ts
+++ b/lib/common/value-util.ts
@@ -1,6 +1,50 @@
+import { IntOrString } from "../../imports/k8s";
+
 /**
  * Ensure an array of values even if only a single value is passed.
  */
 export function ensureArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Returns a scaled value from an IntOrString type.
+ *
+ * If the IntOrString is a percentage string value it's treated as a percentage
+ * and scaled appropriately in accordance to the total, if it's an int value it
+ * is treated as a simple value and if it is a string value which is either
+ * non-numeric or numeric but lacking a trailing '%' it returns an error.
+ *
+ * @see https://github.com/kubernetes/kubernetes/blob/v1.28.0/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go#L155
+ *
+ * @param intOrString Given IntOrString
+ * @param total Total value for percentage calculations
+ * @returns Number value
+ */
+export function getValueFromIntOrPercent(
+  intOrString: IntOrString | string | number,
+  total: number,
+  roundUp = true,
+): number {
+  const value =
+    intOrString instanceof IntOrString ? intOrString.value : intOrString;
+
+  if (typeof value === "string") {
+    if (!value.endsWith("%")) {
+      throw new Error(`Invalid type: ${value} is not a percentage`);
+    }
+
+    const percentage = Number(value.slice(0, -1));
+    if (Number.isNaN(percentage)) {
+      throw new Error(`Invalid value: ${value} is not a number`);
+    }
+
+    if (roundUp) {
+      return Math.ceil((percentage / 100) * total);
+    }
+
+    return Math.floor((percentage / 100) * total);
+  }
+
+  return value;
 }

--- a/lib/talis-chart/calculate-resource-quota.ts
+++ b/lib/talis-chart/calculate-resource-quota.ts
@@ -16,6 +16,7 @@ import {
 } from "../../imports/k8s";
 import { ScaledObject, ScaledObjectSpec } from "../../imports/keda.sh";
 import { WebService } from "../web-service";
+import { getValueFromIntOrPercent } from "../common";
 
 const workloadKinds = [
   "Pod",
@@ -133,12 +134,7 @@ function getPodMaxSurge(workload: KubeObject, replicas: number) {
 
   const maxSurge = workload.spec?.strategy?.rollingUpdate?.maxSurge ?? "25%";
 
-  if (typeof maxSurge === "string" && maxSurge.endsWith("%")) {
-    const percentage = Number(maxSurge.slice(0, -1));
-    return Math.ceil((percentage / 100) * replicas);
-  }
-
-  return Number(maxSurge);
+  return getValueFromIntOrPercent(maxSurge, replicas);
 }
 
 export function calculateResourceQuota(

--- a/lib/web-service/resque-web.ts
+++ b/lib/web-service/resque-web.ts
@@ -15,8 +15,13 @@ export class ResqueWeb extends Construct {
   constructor(scope: Construct, id: string, props: ResqueWebProps) {
     super(scope, id);
 
+    const hasProp = (key: string) =>
+      Object.prototype.hasOwnProperty.call(props, key);
     const release = props.release ?? "stable";
     const applicationPort = props.port ?? 3000;
+    const podDisruptionBudget = hasProp("podDisruptionBudget")
+      ? props.podDisruptionBudget
+      : undefined;
 
     const ingressAnnotations: { [key: string]: string } = {
       "alb.ingress.kubernetes.io/healthcheck-path": "/status",
@@ -97,6 +102,7 @@ export class ResqueWeb extends Construct {
         ...ingressAnnotations,
         ...props.ingressAnnotations,
       },
+      podDisruptionBudget,
     });
   }
 }

--- a/lib/web-service/web-service-props.ts
+++ b/lib/web-service/web-service-props.ts
@@ -1,4 +1,4 @@
-import { Probe, ResourceRequirements } from "../../imports/k8s";
+import { IntOrString, Probe, ResourceRequirements } from "../../imports/k8s";
 import { ContainerProps, WorkloadProps } from "../common";
 
 export const canaryStages = ["base", "canary", "post-canary", "full"] as const;
@@ -16,6 +16,14 @@ export interface HorizontalPodAutoscalerProps {
 
   /** Target average memory utilization, as a percentage of the request. */
   readonly memoryTargetUtilization?: number;
+}
+
+export interface PodDisruptionBudgetProps {
+  /** An eviction is allowed if at most "maxUnavailable" pods are unavailable after the eviction. */
+  readonly maxUnavailable?: IntOrString;
+
+  /** An eviction is allowed if at least "minAvailable" pods will still be available after the eviction. */
+  readonly minAvailable?: IntOrString;
 }
 
 export interface NginxContainerProps {
@@ -192,4 +200,9 @@ export interface WebServiceProps
    * Additional external hostnames, they will be added as Ingress rules.
    */
   readonly additionalExternalHostnames?: string[];
+
+  /**
+   * Whether to include PodDisruptionBudget.
+   */
+  readonly podDisruptionBudget?: PodDisruptionBudgetProps;
 }

--- a/test/common/__snapshots__/value-util.test.ts.snap
+++ b/test/common/__snapshots__/value-util.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`value-util > getValueFromIntOrPercent > throws if string does not have % suffic 1`] = `"Invalid type: 42 is not a percentage"`;
+
+exports[`value-util > getValueFromIntOrPercent > throws if string is not a percentage number 1`] = `"Invalid value: foo% is not a number"`;

--- a/test/common/value-util.test.ts
+++ b/test/common/value-util.test.ts
@@ -1,4 +1,5 @@
-import { ensureArray } from "../../lib";
+import { IntOrString } from "../../imports/k8s";
+import { ensureArray, getValueFromIntOrPercent } from "../../lib";
 
 describe("value-util", () => {
   describe("ensureArray", () => {
@@ -16,6 +17,51 @@ describe("value-util", () => {
 
     test("returns an array from an array of numbers", () => {
       expect(ensureArray([1, 2])).toEqual([1, 2]);
+    });
+  });
+
+  describe("getValueFromIntOrPercent", () => {
+    test.each([
+      [IntOrString.fromNumber(1), 99, 1],
+      [IntOrString.fromNumber(2), 99, 2],
+    ])("returns a number from a number %o", (intOrStr, reference, expected) => {
+      expect(getValueFromIntOrPercent(intOrStr, reference)).toEqual(expected);
+    });
+
+    test.each([
+      [IntOrString.fromString("1%"), 2, 1],
+      [IntOrString.fromString("33%"), 3, 1],
+      [IntOrString.fromString("34%"), 3, 2],
+      [IntOrString.fromString("50%"), 5, 3],
+    ])(
+      "returns a number from a percentage string %o, rounded up",
+      (value, total, expected) => {
+        expect(getValueFromIntOrPercent(value, total)).toEqual(expected);
+      },
+    );
+
+    test.each([
+      [IntOrString.fromString("1%"), 2, 0],
+      [IntOrString.fromString("33%"), 3, 0],
+      [IntOrString.fromString("34%"), 3, 1],
+      [IntOrString.fromString("50%"), 5, 2],
+    ])(
+      "returns a number from a percentage string %o, rounded down",
+      (value, total, expected) => {
+        expect(getValueFromIntOrPercent(value, total, false)).toEqual(expected);
+      },
+    );
+
+    test("throws if string does not have % suffic", () => {
+      expect(() => {
+        getValueFromIntOrPercent(IntOrString.fromString("42"), 42);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test("throws if string is not a percentage number", () => {
+      expect(() => {
+        getValueFromIntOrPercent(IntOrString.fromString("foo%"), 42);
+      }).toThrowErrorMatchingSnapshot();
     });
   });
 });

--- a/test/web-service/__snapshots__/web-service.test.ts.snap
+++ b/test/web-service/__snapshots__/web-service.test.ts.snap
@@ -501,6 +501,35 @@ exports[`WebService > Props > All the props 1`] = `
     },
   },
   {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app": "my-app",
+        "canary": "false",
+        "environment": "test",
+        "foo": "bar",
+        "instance": "my-app",
+        "region": "testing",
+        "role": "server",
+      },
+      "name": "test-web-web-pdb-c86ae522",
+      "namespace": "props-test",
+    },
+    "spec": {
+      "maxUnavailable": "25%",
+      "selector": {
+        "matchLabels": {
+          "app": "my-app",
+          "canary": "false",
+          "foo": "bar",
+          "instance": "my-app",
+          "role": "server",
+        },
+      },
+    },
+  },
+  {
     "apiVersion": "v1",
     "kind": "Service",
     "metadata": {
@@ -906,6 +935,10 @@ exports[`WebService > Props > Either horizontalPodAutoscaler or replicas can be 
 
 exports[`WebService > Props > Either horizontalPodAutoscaler or replicas must be specified 1`] = `"Either horizontalPodAutoscaler or replicas must be specified"`;
 
+exports[`WebService > Props > Either minAvailable or maxUnavailable can be specified for podDisruptionBudget, not both 1`] = `"Either horizontalPodAutoscaler or replicas must be specified"`;
+
+exports[`WebService > Props > Either minAvailable or maxUnavailable must be specified for podDisruptionBudget 1`] = `"Either horizontalPodAutoscaler or replicas must be specified"`;
+
 exports[`WebService > Props > Horizontal Pod Autoscaler 1`] = `
 [
   {
@@ -1103,6 +1136,27 @@ exports[`WebService > Props > Horizontal Pod Autoscaler 1`] = `
         "apiVersion": "apps/v1",
         "kind": "Deployment",
         "name": "web",
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "instance": "web",
+        "role": "server",
+      },
+      "name": "web-pdb",
+      "namespace": "test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "instance": "web",
+          "role": "server",
+        },
       },
     },
   },
@@ -1319,6 +1373,27 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for both memory and cpu 
       },
     },
   },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "instance": "web",
+        "role": "server",
+      },
+      "name": "web-pdb",
+      "namespace": "test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "instance": "web",
+          "role": "server",
+        },
+      },
+    },
+  },
 ]
 `;
 
@@ -1519,6 +1594,27 @@ exports[`WebService > Props > Horizontal Pod Autoscaler for memory 1`] = `
         "apiVersion": "apps/v1",
         "kind": "Deployment",
         "name": "web",
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "instance": "web",
+        "role": "server",
+      },
+      "name": "web-pdb",
+      "namespace": "test",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "instance": "web",
+          "role": "server",
+        },
       },
     },
   },

--- a/test/web-service/resque-web.test.ts
+++ b/test/web-service/resque-web.test.ts
@@ -1,5 +1,6 @@
 import { Testing } from "cdk8s";
 import { ResqueWeb } from "../../lib";
+import { IntOrString } from "../../imports/k8s";
 
 describe("ResqueWeb", () => {
   test("Creates resque web objects", () => {
@@ -60,5 +61,29 @@ describe("ResqueWeb", () => {
     });
     const results = Testing.synth(chart);
     expect(results).toMatchSnapshot();
+  });
+
+  test("It does not include podDisruptionBudget by default", () => {
+    const chart = Testing.chart();
+    new ResqueWeb(chart, "resque-web", {
+      externalUrl: "http://resque.example.com",
+    });
+    const results = Testing.synth(chart);
+    const pdbs = results.filter((obj) => obj.kind === "PodDisruptionBudget");
+    expect(pdbs).toHaveLength(0);
+  });
+
+  test("Allows specifying podDisruptionBudget", () => {
+    const chart = Testing.chart();
+    new ResqueWeb(chart, "resque-web", {
+      externalUrl: "http://resque.example.com",
+      replicas: 2,
+      podDisruptionBudget: {
+        maxUnavailable: IntOrString.fromNumber(1),
+      },
+    });
+    const results = Testing.synth(chart);
+    const pdbs = results.filter((obj) => obj.kind === "PodDisruptionBudget");
+    expect(pdbs).toHaveLength(1);
   });
 });


### PR DESCRIPTION
* Related to https://github.com/talis/platform/issues/6711.
* Introduce PodDisruptionBudget into WebService construct, default to `minAvailable: 1`.