### PR TITLE
chore: make semantic-release work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "cdk8s": "^2.64.2",
         "cdk8s-cli": "^2.70.0",
         "constructs": "^10.2.70",
-        "conventional-changelog-conventionalcommits": "^7.0.1",
+        "conventional-changelog-conventionalcommits": "^6.1.0",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
         "husky": "^8.0.3",
@@ -212,18 +212,6 @@
       },
       "engines": {
         "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
-      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -1812,9 +1800,9 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/parse-json": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
-      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
+      "integrity": "sha512-ihtdrgbqdONYD156Ap6qTcaGcGdkdAxodO1wLqQ/j7HP1u2sFYppINiq4jyC8F+Nm+4fVufylCV00QmkTHkSUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -2111,9 +2099,9 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/parse-json": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
-      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
+      "integrity": "sha512-ihtdrgbqdONYD156Ap6qTcaGcGdkdAxodO1wLqQ/j7HP1u2sFYppINiq4jyC8F+Nm+4fVufylCV00QmkTHkSUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
@@ -2673,7 +2661,6 @@
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -3513,7 +3500,6 @@
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -3857,15 +3843,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.1.tgz",
-      "integrity": "sha512-VfFJxBmi+LYXeb4pIfZGbuaFCpWZh0qXbUAKP/s6B8tigV6R4D8j5PDlTtMMWawa7+DcNySVoF7kPWz0EMYuCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+      "integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -5421,9 +5407,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
@@ -11005,7 +10991,6 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -12150,9 +12135,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/parse-json": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
-      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
+      "integrity": "sha512-ihtdrgbqdONYD156Ap6qTcaGcGdkdAxodO1wLqQ/j7HP1u2sFYppINiq4jyC8F+Nm+4fVufylCV00QmkTHkSUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cdk8s": "^2.64.2",
     "cdk8s-cli": "^2.70.0",
     "constructs": "^10.2.70",
-    "conventional-changelog-conventionalcommits": "^7.0.1",
+    "conventional-changelog-conventionalcommits": "^6.1.0",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
     "husky": "^8.0.3",

--- a/release.config.js
+++ b/release.config.js
@@ -1,18 +1,9 @@
 module.exports = {
   branches: ["main"],
+  preset: "conventionalcommits",
   plugins: [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        preset: "conventionalcommits",
-      },
-    ],
-    [
-      "@semantic-release/release-notes-generator",
-      {
-        preset: "conventionalcommits",
-      },
-    ],
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
     [
       "@semantic-release/npm",
       {


### PR DESCRIPTION
* downgrade `conventional-changelog-conventionalcommits` to v6 - v7 just causes semantic-release to die on:
    ```
    Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
    ```
* simplify release config by putting preset at the top level rather than for each individual plugin.