### PR TITLE
feat: add addLabels utility

### DIFF
--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,5 +1,6 @@
 export * from "./container-props";
 export * from "./env-util";
+export * from "./metadata-util";
 export * from "./name-util";
 export * from "./statefulset-util";
 export * from "./value-util";

--- a/lib/common/metadata-util.ts
+++ b/lib/common/metadata-util.ts
@@ -1,0 +1,53 @@
+import { ApiObject, JsonPatch } from "cdk8s";
+
+const workloadsWithPodTemplateKinds = [
+  "DaemonSet",
+  "Deployment",
+  "Job",
+  "StatefulSet",
+];
+
+/**
+ * Sets given labels to API objects, and also to their pod templates.
+ * @param apiObjects Array of API objects, e.g. from Helm, Include, etc.
+ * @param labels Labels to set
+ */
+export function addLabels(
+  apiObjects: ApiObject[],
+  labels: Record<string, string>,
+): void {
+  const labelEntries = Object.entries(labels);
+
+  apiObjects.forEach((object) => {
+    labelEntries.forEach(([key, value]) => {
+      object.metadata.addLabel(key, value);
+    });
+
+    if (workloadsWithPodTemplateKinds.includes(object.kind)) {
+      const workload = object.toJson();
+      const selector =
+        (workload?.spec?.selector?.matchLabels as Record<string, string>) ?? {};
+
+      labelEntries.forEach(([key, value]) => {
+        if (key in selector && selector[key] !== value) {
+          throw new Error(`Setting ${key} label would overwrite selector`);
+        }
+        object.addJsonPatch(
+          JsonPatch.add(`/spec/template/metadata/labels/${key}`, value),
+        );
+      });
+    }
+
+    if (object.kind === "CronJob") {
+      labelEntries.forEach(([key, value]) => {
+        object.addJsonPatch(
+          JsonPatch.add(`/spec/jobTemplate/metadata/labels/${key}`, value),
+          JsonPatch.add(
+            `/spec/jobTemplate/spec/template/metadata/labels/${key}`,
+            value,
+          ),
+        );
+      });
+    }
+  });
+}

--- a/test/common/metadata-util.test.ts
+++ b/test/common/metadata-util.test.ts
@@ -1,0 +1,248 @@
+import { ApiObject, Testing } from "cdk8s";
+import { KubeDeployment } from "../../imports/k8s";
+import { addLabels } from "../../lib";
+import { makeChart } from "../test-util";
+
+describe("metadata-util", () => {
+  describe("addLabels", () => {
+    test("adds labels to given ApiObjects", () => {
+      const chart = makeChart();
+      addLabels(
+        [
+          new ApiObject(chart, "config-map", {
+            apiVersion: "v1",
+            kind: "ConfigMap",
+          }),
+          new ApiObject(chart, "secret", {
+            apiVersion: "v1",
+            kind: "Secret",
+          }),
+          new ApiObject(chart, "service", {
+            apiVersion: "v1",
+            kind: "Service",
+          }),
+        ],
+        { foo: "bar", baz: "qux" },
+      );
+
+      const results = Testing.synth(chart);
+
+      const configMap = results.find((o) => o.kind === "ConfigMap");
+      expect(configMap).toHaveProperty("metadata.labels.foo", "bar");
+      expect(configMap).toHaveProperty("metadata.labels.baz", "qux");
+      const secret = results.find((o) => o.kind === "Secret");
+      expect(secret).toHaveProperty("metadata.labels.foo", "bar");
+      expect(secret).toHaveProperty("metadata.labels.baz", "qux");
+      const service = results.find((o) => o.kind === "Service");
+      expect(service).toHaveProperty("metadata.labels.foo", "bar");
+      expect(service).toHaveProperty("metadata.labels.baz", "qux");
+    });
+
+    test("adds labels to Pod templates", () => {
+      const chart = makeChart();
+      const template = {
+        metadata: {
+          labels: { app: "app" },
+        },
+        spec: {
+          containers: [{ name: "app" }],
+        },
+      };
+      addLabels(
+        [
+          new ApiObject(chart, "daemonSet", {
+            apiVersion: "apps/v1",
+            kind: "DaemonSet",
+            spec: {
+              selector: { matchLabels: { app: "app" } },
+              template: template,
+            },
+          }),
+          new ApiObject(chart, "deployment", {
+            apiVersion: "apps/v1",
+            kind: "Deployment",
+            spec: {
+              selector: { matchLabels: { app: "app" } },
+              template: template,
+            },
+          }),
+          new ApiObject(chart, "job", {
+            apiVersion: "batch/v1",
+            kind: "Job",
+            spec: {
+              selector: { matchLabels: { app: "app" } },
+              template: template,
+            },
+          }),
+          new ApiObject(chart, "statefulSet", {
+            apiVersion: "apps/v1",
+            kind: "StatefulSet",
+            spec: {
+              serviceName: "test",
+              selector: { matchLabels: { app: "app" } },
+              template: template,
+            },
+          }),
+        ],
+        { foo: "bar", baz: "qux" },
+      );
+
+      const results = Testing.synth(chart);
+
+      const ds = results.find((o) => o.kind === "DaemonSet");
+      expect(ds).toHaveProperty("metadata.labels.foo", "bar");
+      expect(ds).toHaveProperty("metadata.labels.baz", "qux");
+      expect(ds).toHaveProperty("spec.template.metadata.labels.foo", "bar");
+      expect(ds).toHaveProperty("spec.template.metadata.labels.baz", "qux");
+
+      const deploy = results.find((o) => o.kind === "Deployment");
+      expect(deploy).toHaveProperty("metadata.labels.foo", "bar");
+      expect(deploy).toHaveProperty("metadata.labels.baz", "qux");
+      expect(deploy).toHaveProperty("spec.template.metadata.labels.foo", "bar");
+      expect(deploy).toHaveProperty("spec.template.metadata.labels.baz", "qux");
+
+      const job = results.find((o) => o.kind === "Job");
+      expect(job).toHaveProperty("metadata.labels.foo", "bar");
+      expect(job).toHaveProperty("metadata.labels.baz", "qux");
+      expect(job).toHaveProperty("spec.template.metadata.labels.foo", "bar");
+      expect(job).toHaveProperty("spec.template.metadata.labels.baz", "qux");
+
+      const sts = results.find((o) => o.kind === "StatefulSet");
+      expect(sts).toHaveProperty("metadata.labels.foo", "bar");
+      expect(sts).toHaveProperty("metadata.labels.baz", "qux");
+      expect(sts).toHaveProperty("spec.template.metadata.labels.foo", "bar");
+      expect(sts).toHaveProperty("spec.template.metadata.labels.baz", "qux");
+    });
+
+    test("adds labels to imported constructs", () => {
+      const chart = makeChart();
+      addLabels(
+        [
+          new KubeDeployment(chart, "deployment", {
+            spec: {
+              selector: { matchLabels: { app: "app" } },
+              template: {
+                metadata: {
+                  labels: { app: "app" },
+                },
+                spec: {
+                  containers: [{ name: "app" }],
+                },
+              },
+            },
+          }),
+        ],
+        { foo: "bar", baz: "qux" },
+      );
+
+      const results = Testing.synth(chart);
+
+      const deploy = results.find((o) => o.kind === "Deployment");
+      expect(deploy).toHaveProperty("metadata.labels.foo", "bar");
+      expect(deploy).toHaveProperty("metadata.labels.baz", "qux");
+      expect(deploy).toHaveProperty("spec.template.metadata.labels.foo", "bar");
+      expect(deploy).toHaveProperty("spec.template.metadata.labels.baz", "qux");
+    });
+
+    test("adds labels to Job and Pod templates in CronJob", () => {
+      const chart = makeChart();
+      addLabels(
+        [
+          new ApiObject(chart, "cronJob", {
+            apiVersion: "batch/v1",
+            kind: "CronJob",
+            spec: {
+              schedule: "0 0 * * *",
+              jobTemplate: {
+                metadata: {
+                  labels: { app: "app" },
+                },
+                spec: {
+                  template: {
+                    metadata: {
+                      labels: { app: "app" },
+                    },
+                    spec: {
+                      containers: [{ name: "app" }],
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        ],
+        { foo: "bar", baz: "qux" },
+      );
+
+      const results = Testing.synth(chart);
+
+      const cron = results.find((o) => o.kind === "CronJob");
+      expect(cron).toHaveProperty("metadata.labels.foo", "bar");
+      expect(cron).toHaveProperty("metadata.labels.baz", "qux");
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.metadata.labels.foo",
+        "bar",
+      );
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.metadata.labels.baz",
+        "qux",
+      );
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.metadata.labels.foo",
+        "bar",
+      );
+      expect(cron).toHaveProperty(
+        "spec.jobTemplate.spec.template.metadata.labels.baz",
+        "qux",
+      );
+    });
+  });
+
+  test("throws an error when a label is already set on a selector", () => {
+    const chart = makeChart();
+    expect(() => {
+      addLabels(
+        [
+          new KubeDeployment(chart, "deployment", {
+            spec: {
+              selector: { matchLabels: { app: "test-app" } },
+              template: {
+                metadata: {
+                  labels: { app: "test-app" },
+                },
+                spec: {
+                  containers: [{ name: "test" }],
+                },
+              },
+            },
+          }),
+        ],
+        { app: "different-app", foo: "bar" },
+      );
+    }).toThrowError("Setting app label would overwrite selector");
+  });
+
+  test("allows to set a label that is used in selector if values are the same", () => {
+    const chart = makeChart();
+    expect(() => {
+      addLabels(
+        [
+          new KubeDeployment(chart, "deployment", {
+            spec: {
+              selector: { matchLabels: { app: "test-app" } },
+              template: {
+                metadata: {
+                  labels: { app: "test-app" },
+                },
+                spec: {
+                  containers: [{ name: "test" }],
+                },
+              },
+            },
+          }),
+        ],
+        { app: "test-app", foo: "bar" },
+      );
+    }).not.toThrowError();
+  });
+});


### PR DESCRIPTION
Add a utility function that allows to add a set of labels to objects, including to their nested Pod templates.

Example use:

```ts
import { Helm } from "cdk8s";
import { addLabels } from "talis-cdk8s-constructs";

const helm = new Helm(chart, "helm-template", {
  repo: "https://aws.github.io/eks-charts",
  chart: "aws-load-balancer-controller",
  releaseName: "aws-load-balancer-controller",
  version: "1.6.1",
});

addLabels(helm.apiObjects, {
  "my-label": "my-value",
});
```