### PR TITLE
feat(ta-730): add partitioned cookie config

### DIFF
--- a/lib/web-service/nginx-util.ts
+++ b/lib/web-service/nginx-util.ts
@@ -29,6 +29,15 @@ interface NginxConfigMapProps {
    * @default false
    */
   readonly includeSameSiteCookiesConfig?: boolean;
+
+  /**
+   * Whether to include a config that patches Set-Cookies header to include `Partitioned`
+   * For further details on partitioned cookies visit:
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies
+   * @default false
+   */
+  readonly includePartionedCookiesConfig?: boolean;
 }
 
 /**
@@ -45,6 +54,10 @@ function createConfigMap(
 
   if (props.includeSameSiteCookiesConfig) {
     data["samesite.conf"] = getSameSiteCookiesConfig();
+  }
+
+  if (props.includePartionedCookiesConfig) {
+    data["partitioned.conf"] = getPartitionedCookiesConfig();
   }
 
   const configMap = new ConfigMap(scope, "nginx-config", { data });
@@ -86,6 +99,16 @@ function getDefaultConfig(
  */
 function getSameSiteCookiesConfig(): string {
   return fs.readFileSync(resolvePath("nginx/samesite.conf"), "utf8");
+}
+
+/**
+ * Return the contents of an Nginx configuration file that patches
+ * `Set-Cookie` headers to use the `Partitioned` flag
+ *
+ * The output of this function is used with `createConfigMap` with `includePartionedCookesConfig` enabled.
+ */
+function getPartitionedCookiesConfig(): string {
+  return fs.readFileSync(resolvePath("nginx/partitioned.conf"), "utf8");
 }
 
 export const nginxUtil = {

--- a/lib/web-service/nginx-util.ts
+++ b/lib/web-service/nginx-util.ts
@@ -120,7 +120,7 @@ function getPartitionedCookiesConfig(locations: string[]): string {
   );
 
   return `server {
-    ${configs}
+    ${configs.join("\n")}
   }`;
 }
 

--- a/lib/web-service/nginx/partitioned.conf
+++ b/lib/web-service/nginx/partitioned.conf
@@ -1,1 +1,0 @@
-proxy_cookie_path / "/; Partitioned";

--- a/lib/web-service/nginx/partitioned.conf
+++ b/lib/web-service/nginx/partitioned.conf
@@ -1,0 +1,1 @@
+proxy_cookie_path / "/; Partitioned";

--- a/test/web-service/__snapshots__/nginx-util.test.ts.snap
+++ b/test/web-service/__snapshots__/nginx-util.test.ts.snap
@@ -169,15 +169,18 @@ exports[`nginx-util > createConfigMap > Partitioned cookies config 1`] = `
   {
     "apiVersion": "v1",
     "data": {
-      "partitioned.conf": "proxy_cookie_path / "/; Partitioned";
-",
+      "partitioned.conf": "server {
+    location /api/oidclogin {
+      proxy_cookie_path / "/; Partitioned";
+    }
+  }",
     },
     "kind": "ConfigMap",
     "metadata": {
       "labels": {
         "prunable": "true",
       },
-      "name": "test-nginx-config-c88fe926-2ctcd744fb",
+      "name": "test-nginx-config-c88fe926-m8bk7f665d",
     },
   },
 ]

--- a/test/web-service/__snapshots__/nginx-util.test.ts.snap
+++ b/test/web-service/__snapshots__/nginx-util.test.ts.snap
@@ -164,6 +164,25 @@ exports[`nginx-util > createConfigMap > Empty 1`] = `
 ]
 `;
 
+exports[`nginx-util > createConfigMap > Partitioned cookies config 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "data": {
+      "partitioned.conf": "proxy_cookie_path / "/; Partitioned";
+",
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+      "labels": {
+        "prunable": "true",
+      },
+      "name": "test-nginx-config-c88fe926-2ctcd744fb",
+    },
+  },
+]
+`;
+
 exports[`nginx-util > createConfigMap > Same site cookies config 1`] = `
 [
   {

--- a/test/web-service/__snapshots__/nginx-util.test.ts.snap
+++ b/test/web-service/__snapshots__/nginx-util.test.ts.snap
@@ -186,6 +186,31 @@ exports[`nginx-util > createConfigMap > Partitioned cookies config 1`] = `
 ]
 `;
 
+exports[`nginx-util > createConfigMap > Partitioned cookies config with multiple locations 1`] = `
+[
+  {
+    "apiVersion": "v1",
+    "data": {
+      "partitioned.conf": "server {
+    location /api/oidclogin {
+      proxy_cookie_path / "/; Partitioned";
+    }
+location /api/auth/login {
+      proxy_cookie_path / "/; Partitioned";
+    }
+  }",
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+      "labels": {
+        "prunable": "true",
+      },
+      "name": "test-nginx-config-c88fe926-5gf9f48485",
+    },
+  },
+]
+`;
+
 exports[`nginx-util > createConfigMap > Same site cookies config 1`] = `
 [
   {

--- a/test/web-service/nginx-util.test.ts
+++ b/test/web-service/nginx-util.test.ts
@@ -69,7 +69,7 @@ describe("nginx-util", () => {
     test("Partitioned cookies config", () => {
       const chart = Testing.chart();
       nginxUtil.createConfigMap(chart, {
-        includePartionedCookiesConfig: true,
+        usePartionedCookiesLocations: ["/api/oidclogin"],
       });
       const results = Testing.synth(chart);
       expect(results).toMatchSnapshot();

--- a/test/web-service/nginx-util.test.ts
+++ b/test/web-service/nginx-util.test.ts
@@ -75,6 +75,15 @@ describe("nginx-util", () => {
       expect(results).toMatchSnapshot();
     });
 
+    test("Partitioned cookies config with multiple locations", () => {
+      const chart = Testing.chart();
+      nginxUtil.createConfigMap(chart, {
+        usePartionedCookiesLocations: ["/api/oidclogin", "/api/auth/login"],
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
     test("Custom data", () => {
       const chart = Testing.chart();
       nginxUtil.createConfigMap(

--- a/test/web-service/nginx-util.test.ts
+++ b/test/web-service/nginx-util.test.ts
@@ -66,6 +66,15 @@ describe("nginx-util", () => {
       expect(results).toMatchSnapshot();
     });
 
+    test("Partitioned cookies config", () => {
+      const chart = Testing.chart();
+      nginxUtil.createConfigMap(chart, {
+        includePartionedCookiesConfig: true,
+      });
+      const results = Testing.synth(chart);
+      expect(results).toMatchSnapshot();
+    });
+
     test("Custom data", () => {
       const chart = Testing.chart();
       nginxUtil.createConfigMap(


### PR DESCRIPTION
## Problem

* [TA-730](https://techfromsage.atlassian.net/browse/TA-730)

On analysing Elevate's use of LTI.js, we identified that it requires third party cookies. The library has not yet been updated to change this particular feature.

In order for LTI launches to continue to work in Elevate (at least for Chrome-based browsers), we require a solution that allows these cookies to be processed in a PKCE workflow.

The current solution to this issue is [partioned cookies](https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies).

Elevate cannot support this at an LTI.js level, nor at the Express.js level so we must resort to a supporting configuration in nginx.

This new property will load a supporting nginx configuration. 

[TA-730]: https://techfromsage.atlassian.net/browse/TA-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ