### PR TITLE
feat: improvements for Memcached, Mongo, Postgres, and Redis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,18 @@ jobs:
           name: Run e2e tests
           environment:
             DEBUG_DETIK: "true"
-          command: npm run e2e
+          command: |
+            mkdir test-results
+            # dummy directory passed to bats as first to force absolute paths
+            # in JUnit, see https://github.com/bats-core/bats-core/issues/913
+            mkdir dummy
+            TEST_FILES=$(circleci tests glob "e2e/*.bats")
+            echo "$TEST_FILES" | circleci tests run --verbose \
+              --command="xargs npm exec -- bats --jobs 4 --no-parallelize-within-files --timing --print-output-on-failure --report-formatter junit --output test-results dummy"
       - store_artifacts:
           path: /tmp/detik
+      - store_test_results:
+          path: test-results
 
 workflows:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage
 node_modules
 .vscode/
+test-results/
 junit.xml
 .huskyrc
 

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ imports/**/*.ts
 lib/**/*.ts
 !lib/**/*.d.ts
 test
+test-results

--- a/e2e/autoscaling-worker.e2e.ts
+++ b/e2e/autoscaling-worker.e2e.ts
@@ -1,19 +1,19 @@
-import { Construct } from "constructs";
 import { App } from "cdk8s";
+import { Construct } from "constructs";
 
-import { Container, Quantity, ResourceRequirements } from "../imports/k8s";
+import { Quantity, ResourceRequirements } from "../imports/k8s";
 import {
-  TalisShortRegion,
-  TalisDeploymentEnvironment,
-  TalisChart,
-  TalisChartProps,
-  Redis,
   BackgroundWorker,
   CronJob,
   PodSpecRestartPolicy,
+  Redis,
+  TalisChart,
+  TalisChartProps,
+  TalisDeploymentEnvironment,
+  TalisShortRegion,
 } from "../lib";
-import { getBuildWatermark, makeTtlTimestamp } from "./test-util";
 import { getRedisConnectionDetails } from "../lib/redis/redis-util";
+import { getBuildWatermark, makeTtlTimestamp } from "./test-util";
 
 export class AutoscalingWorkerChart extends TalisChart {
   constructor(scope: Construct, props: TalisChartProps) {
@@ -43,16 +43,7 @@ export class AutoscalingWorkerChart extends TalisChart {
       host: redisHost,
     });
 
-    const initRedisContainer: Container = {
-      name: "init-redis",
-      image: busyboxImage,
-      command: [
-        "sh",
-        "-c",
-        `until nc -vz -w1 ${redisConnectionDetails.host} ${redisConnectionDetails.port}; do echo waiting for redis; sleep 1; done`,
-      ],
-      resources: commonResources,
-    };
+    const initRedisContainer = redis.getWaitForPortContainer();
 
     const jobs = [
       {

--- a/e2e/full-stack.e2e.ts
+++ b/e2e/full-stack.e2e.ts
@@ -36,7 +36,7 @@ export class FullStackChart extends TalisChart {
     const { domain, watermark } = props;
     const applicationPort = 9898;
     const podinfoVersion = "6.1.3";
-    const mongoVersion = "5.0.7";
+    const mongoVersion = "4.4.29";
     const redisVersion = "5.0.7";
     const busyboxVersion = "1.35.0";
     const busyboxImage = `docker.io/busybox:${busyboxVersion}`;

--- a/e2e/rails-app.e2e.ts
+++ b/e2e/rails-app.e2e.ts
@@ -27,7 +27,6 @@ export class RubyOnRailsAppChart extends TalisChart {
     const redmineVersion = "5.0.2";
     const postgresVersion = "14.4";
     const memcachedVersion = "1.6.15";
-    const busyboxVersion = "1.35.0";
 
     const commonResources: ResourceRequirements = {
       requests: {
@@ -98,26 +97,8 @@ export class RubyOnRailsAppChart extends TalisChart {
       port: applicationPort,
       resources: commonResources,
       initContainers: [
-        {
-          name: "init-postgres",
-          image: `docker.io/busybox:${busyboxVersion}`,
-          command: [
-            "sh",
-            "-c",
-            `until nc -vz -w1 ${postgresHost} 5432; do echo waiting for postgres; sleep 1; done`,
-          ],
-          resources: commonResources,
-        },
-        {
-          name: "init-memcached",
-          image: `docker.io/busybox:${busyboxVersion}`,
-          command: [
-            "sh",
-            "-c",
-            `until nc -vz -w1 ${memcachedHost} 11211; do echo waiting for memcached; sleep 1; done`,
-          ],
-          resources: commonResources,
-        },
+        postgres.getWaitForPortContainer(),
+        memcached.getWaitForPortContainer(),
       ],
       env: [
         {
@@ -157,7 +138,7 @@ export class RubyOnRailsAppChart extends TalisChart {
         },
         {
           name: "MEMCACHED_PORT",
-          value: "11211",
+          value: memcached.port.toString(),
         },
       ],
       startupProbe: {

--- a/lib/common/container-util.ts
+++ b/lib/common/container-util.ts
@@ -1,0 +1,37 @@
+import { Quantity } from "../../imports/k8s";
+
+/**
+ * Create a container that will wait on the availability of a host and TCP port.
+ * Useful as an initContainer to wait for service dependencies.
+ *
+ * @param name Container name suffix (name of the service it will wait for).
+ * @param host Host(s) or IP(s) under test.
+ * @param port TCP port under test.
+ */
+export function makeWaitForPortContainer(
+  name: string,
+  host: string | string[],
+  port: number,
+) {
+  const hosts = typeof host === "string" ? [host] : host;
+  const command =
+    `echo 'waiting for ${name}'; ` +
+    hosts
+      .map((host) => `until nc -vz -w1 ${host} ${port}; do sleep 1; done`)
+      .join(" && ");
+
+  return {
+    name: `wait-for-${name}`,
+    image: "busybox:1.36.1",
+    command: ["/bin/sh", "-c", command],
+    resources: {
+      requests: {
+        cpu: Quantity.fromString("10m"),
+        memory: Quantity.fromString("50Mi"),
+      },
+      limits: {
+        memory: Quantity.fromString("50Mi"),
+      },
+    },
+  };
+}

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,5 +1,6 @@
 export * from "./annotation-util";
 export * from "./container-props";
+export * from "./container-util";
 export * from "./env-util";
 export * from "./metadata-util";
 export * from "./name-util";

--- a/lib/mongo/init/setup-replset.sh
+++ b/lib/mongo/init/setup-replset.sh
@@ -1,27 +1,59 @@
 #!/bin/bash
-### Script to initiate a MongoDB replica set.
-###
-### Usage:
-### setup-replset.sh [RS_NAME] [MEMBERS] <mongo CLI arguments>
-###
-### Arguments:
-### - RS_NAME - name of the replica set.
-### - MEMBERS - hostnames/ip addresses (and optional :port)
-###             of replica set members, comma-separated.
-###
-### Example:
-### setup-replset.sh rs0 mongo-1.domain:27017,mongo-2.domain:27017
-###
 
-set -Eeuo pipefail
+set -eo pipefail
 
 help() {
-  awk -F'### ' '/^###/ { print $2 }' "$0"
+  cat <<EOS
+Script to initiate a MongoDB replica set.
+
+Usage:
+setup-replset.sh [OPTION]... [RS_NAME] [MEMBERS] <mongo CLI arguments>
+
+Options:
+  -h, --help            Display this message and exit.
+      --no-init         Don't initialize the replica set, only wait for it.
+
+Arguments:
+- RS_NAME - name of the replica set.
+- MEMBERS - hostnames/ip addresses (and optional :port)
+            of replica set members, comma-separated.
+
+Example:
+$0 rs0 mongo-1.domain:27017,mongo-2.domain:27017
+EOS
 }
 
-RS_NAME=$1
-MEMBERS=$2
-shift 2
+DO_INIT=true
+RS_NAME=
+MEMBERS=
+MONGO_OPTS=()
+END_OF_OPTIONS=false
+
+arg_num=0
+while [ "$#" -gt 0 ]; do
+  if [[ "$END_OF_OPTIONS" == "true" ]]; then
+    MONGO_OPTS+=("$1")
+  else
+    case "$1" in
+    -h | --help)
+      help
+      exit 0
+      ;;
+    --no-init) DO_INIT=false ;;
+    *)
+      arg_num=$((arg_num + 1))
+      case "$arg_num" in
+      1) RS_NAME="$1" ;;
+      2)
+        MEMBERS="$1"
+        END_OF_OPTIONS=true
+        ;;
+      esac
+      ;;
+    esac
+  fi
+  shift
+done
 
 if [[ -z "$RS_NAME" || -z "$MEMBERS" ]]; then
   help
@@ -29,54 +61,43 @@ if [[ -z "$RS_NAME" || -z "$MEMBERS" ]]; then
 fi
 
 IFS=',' read -r -a MEMBERS_ARR <<<"$MEMBERS"
-if [[ "${#MEMBERS_ARR[@]}" -lt 1 ]]; then
-  echo >&2 "MEMBERS must contain replica set member hostnames"
-  exit 1
-fi
-
-FIRST_MEMBER=${MEMBERS_ARR[0]}
-
-MONGO_CLI=$(command -v mongosh mongo | head -n1)
-MONGO_OPTS=(--host "$FIRST_MEMBER" "$@")
-
-# Check if we can connect
-for _ in $(seq 300); do
-  if "$MONGO_CLI" "${MONGO_OPTS[@]}" --eval 'db.adminCommand("ping")' >/dev/null 2>&1; then
-    break
-  else
-    printf '.'
-    sleep 1
-  fi
+INITIATOR=${MEMBERS_ARR[0]}
+MEMBERS_JS=''
+for i in "${!MEMBERS_ARR[@]}"; do
+  MEMBERS_JS="${MEMBERS_JS}$(printf '{ _id: %d, host: "%s" },' "$i" "${MEMBERS_ARR[$i]}")"
 done
 
-# Is it already a replica set?
-if "$MONGO_CLI" "${MONGO_OPTS[@]}" --eval 'rs.secondaryOk(); rs.conf();' 2>/dev/null; then
-  echo "Already a replica set"
-  exit
+MONGO_CLI="$(command -v mongo mongosh | head -n1)"
+_mongo() {
+  "$MONGO_CLI" --quiet "${MONGO_OPTS[@]}" --host "$@"
+}
+
+for member in "${MEMBERS_ARR[@]}"; do
+  echo >&2 "Waiting for $member"
+  timeout=300
+  until _mongo "$member" <<<'db.adminCommand("ping")' | grep 'ok'; do
+    sleep 1
+    ((timeout = timeout - 1))
+    if [[ "$timeout" -eq 0 ]]; then
+      echo >&2 "Could not connect to $member"
+      exit 1
+    fi
+  done
+done
+
+if [[ "$DO_INIT" == "true" ]]; then
+  echo >&2 "Initiating replica set $RS_NAME..."
+  _mongo "$INITIATOR" <<<"$(printf 'rs.initiate({ _id: "%s", members: [%s] })' "$RS_NAME" "$MEMBERS_JS")" |
+    tee /dev/stderr | grep -q -E 'ok|already initialized'
 fi
 
-MEMBERS_JS=$(
-  jq --null-input --arg 'str' "$MEMBERS" "$(
-    cat <<'EOS'
-$str | split(",") | [range(length) as $i | .[$i] | {
-  _id: $i,
-  host: (. | if contains(":") then . else "\(.):27017" end),
-}]
-EOS
-  )"
-)
+echo >&2 'Waiting for primary...'
+_mongo "$INITIATOR" <<<'while (true) { if (rs.status().members.some(({ state }) => state === 1)) { break; } sleep(1000); }'
 
-"$MONGO_CLI" "${MONGO_OPTS[@]}" <<EOS
-  rs.initiate({
-    _id: "$RS_NAME",
-    members: $MEMBERS_JS,
-    settings: { chainingAllowed: true },
-  });
-  for (let s = 0; s < 300; s++) {
-    sleep(1);
-    if (rs.status().members.every(({state}) => state == 1 || state == 2)) {
-      break;
-    }
-  }
-  rs.status();
-EOS
+echo >&2 'Waiting for secondaries...'
+_mongo "$INITIATOR" <<<'while (true) { if (rs.status().members.every(({state}) => state === 1 || state === 2)) { break; } sleep(1000); }'
+
+echo >&2 'Checking status...'
+_mongo "$INITIATOR" <<<'rs.status();' | tee /dev/stderr | grep -q "$RS_NAME"
+
+echo >&2 "Replica set $RS_NAME configured!"

--- a/test/common/container-util.test.ts
+++ b/test/common/container-util.test.ts
@@ -1,0 +1,65 @@
+import { makeWaitForPortContainer } from "../../lib";
+
+describe("container-util", () => {
+  describe("makeWaitForPortContainer", () => {
+    test("Creates a container that waits for a single host and port", () => {
+      expect(makeWaitForPortContainer("single", "test.example.com", 4321))
+        .toMatchInlineSnapshot(`
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "echo 'waiting for single'; until nc -vz -w1 test.example.com 4321; do sleep 1; done",
+          ],
+          "image": "busybox:1.36.1",
+          "name": "wait-for-single",
+          "resources": {
+            "limits": {
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+            "requests": {
+              "cpu": Quantity {
+                "value": "10m",
+              },
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    test("Creates a container that waits for a multiple hosts", () => {
+      expect(makeWaitForPortContainer("multi", ["host1", "host2"], 5678))
+        .toMatchInlineSnapshot(`
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "echo 'waiting for multi'; until nc -vz -w1 host1 5678; do sleep 1; done && until nc -vz -w1 host2 5678; do sleep 1; done",
+          ],
+          "image": "busybox:1.36.1",
+          "name": "wait-for-multi",
+          "resources": {
+            "limits": {
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+            "requests": {
+              "cpu": Quantity {
+                "value": "10m",
+              },
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+          },
+        }
+      `);
+    });
+  });
+});

--- a/test/memcached/memcached.test.ts
+++ b/test/memcached/memcached.test.ts
@@ -79,6 +79,12 @@ describe("Memcached", () => {
   });
 
   describe("Object instances", () => {
+    test("Exposes service port through property", () => {
+      const chart = makeChart();
+      const memcached = new Memcached(chart, "memcached-test", requiredProps);
+      expect(memcached.port).toBe(11211);
+    });
+
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const memcached = new Memcached(chart, "memcached-test", requiredProps);
@@ -147,6 +153,39 @@ describe("Memcached", () => {
         const memcached = new Memcached(chart, "memcached-test", requiredProps);
         expect(memcached.getDnsName(replica)).toBe(expected);
       });
+    });
+  });
+
+  describe("getWaitForPortContainer", () => {
+    test("Gets a wait container for a single host", () => {
+      const chart = makeChart({ namespace: "test-ns" });
+      const memcached = new Memcached(chart, "memcached-test", requiredProps);
+      expect(memcached.getWaitForPortContainer()).toMatchInlineSnapshot(`
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "echo 'waiting for memcached-test'; until nc -vz -w1 memcached-test-sts-0.memcached-test.test-ns.svc.cluster.local 11211; do sleep 1; done",
+          ],
+          "image": "busybox:1.36.1",
+          "name": "wait-for-memcached-test",
+          "resources": {
+            "limits": {
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+            "requests": {
+              "cpu": Quantity {
+                "value": "10m",
+              },
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+          },
+        }
+      `);
     });
   });
 });

--- a/test/mongo/__snapshots__/mongo.test.ts.snap
+++ b/test/mongo/__snapshots__/mongo.test.ts.snap
@@ -16,7 +16,7 @@ exports[`Mongo > Props > All the props 1`] = `
         "environment": "test",
         "instance": "test",
         "region": "local",
-        "release": "v1",
+        "release": "4.4.29",
         "role": "mongo",
       },
       "name": "test-mongo-test-c844268f",
@@ -47,7 +47,7 @@ exports[`Mongo > Props > All the props 1`] = `
         "environment": "test",
         "instance": "test",
         "region": "local",
-        "release": "v1",
+        "release": "4.4.29",
         "role": "mongo",
       },
       "name": "test-mongo-test-mongo-test-sts-c8cbd639",
@@ -70,7 +70,7 @@ exports[`Mongo > Props > All the props 1`] = `
             "environment": "test",
             "instance": "test",
             "region": "local",
-            "release": "v1",
+            "release": "4.4.29",
             "role": "mongo",
           },
         },
@@ -81,7 +81,7 @@ exports[`Mongo > Props > All the props 1`] = `
                 "--storageEngine",
                 "wiredTiger",
               ],
-              "image": "mongo:v1",
+              "image": "mongo:4.4.29",
               "livenessProbe": {
                 "failureThreshold": 5,
                 "initialDelaySeconds": 5,
@@ -156,7 +156,7 @@ exports[`Mongo > Props > Minimal required props 1`] = `
     "metadata": {
       "labels": {
         "instance": "mongo-test",
-        "release": "v1",
+        "release": "4.4.29",
         "role": "mongo",
       },
       "name": "test-mongo-test-c844268f",
@@ -182,7 +182,7 @@ exports[`Mongo > Props > Minimal required props 1`] = `
     "metadata": {
       "labels": {
         "instance": "mongo-test",
-        "release": "v1",
+        "release": "4.4.29",
         "role": "mongo",
       },
       "name": "test-mongo-test-mongo-test-sts-c8cbd639",
@@ -200,7 +200,7 @@ exports[`Mongo > Props > Minimal required props 1`] = `
         "metadata": {
           "labels": {
             "instance": "mongo-test",
-            "release": "v1",
+            "release": "4.4.29",
             "role": "mongo",
           },
         },
@@ -212,7 +212,7 @@ exports[`Mongo > Props > Minimal required props 1`] = `
                 "mmapv1",
                 "--smallfiles",
               ],
-              "image": "mongo:v1",
+              "image": "mongo:4.4.29",
               "livenessProbe": {
                 "failureThreshold": 5,
                 "initialDelaySeconds": 5,

--- a/test/mongo/mongo.test.ts
+++ b/test/mongo/mongo.test.ts
@@ -113,6 +113,12 @@ describe("Mongo", () => {
   });
 
   describe("Object instances", () => {
+    test("Exposes service port through property", () => {
+      const chart = makeChart();
+      const mongo = new Mongo(chart, "mongo-test", requiredProps);
+      expect(mongo.port).toBe(27017);
+    });
+
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const mongo = new Mongo(chart, "mongo-test", requiredProps);

--- a/test/postgres/postgres.test.ts
+++ b/test/postgres/postgres.test.ts
@@ -123,6 +123,12 @@ describe("Postgres", () => {
   });
 
   describe("Object instances", () => {
+    test("Exposes service port through property", () => {
+      const chart = makeChart();
+      const postgres = new Postgres(chart, "postgres-test", requiredProps);
+      expect(postgres.port).toBe(5432);
+    });
+
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const postgres = new Postgres(chart, "postgres-test", requiredProps);
@@ -189,6 +195,39 @@ describe("Postgres", () => {
         const postgres = new Postgres(chart, "postgres-test", requiredProps);
         expect(postgres.getDnsName(replica)).toBe(expected);
       });
+    });
+  });
+
+  describe("getWaitForPortContainer", () => {
+    test("Gets a wait container for a single host", () => {
+      const chart = makeChart();
+      const postgres = new Postgres(chart, "postgres-test", requiredProps);
+      expect(postgres.getWaitForPortContainer()).toMatchInlineSnapshot(`
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "echo 'waiting for postgres-test'; until nc -vz -w1 postgres-test-sts-0.postgres-test 5432; do sleep 1; done",
+          ],
+          "image": "busybox:1.36.1",
+          "name": "wait-for-postgres-test",
+          "resources": {
+            "limits": {
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+            "requests": {
+              "cpu": Quantity {
+                "value": "10m",
+              },
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+          },
+        }
+      `);
     });
   });
 });

--- a/test/redis/redis.test.ts
+++ b/test/redis/redis.test.ts
@@ -79,6 +79,12 @@ describe("Redis", () => {
   });
 
   describe("Object instances", () => {
+    test("Exposes service port through property", () => {
+      const chart = makeChart();
+      const redis = new Redis(chart, "redis-test", requiredProps);
+      expect(redis.port).toBe(6379);
+    });
+
     test("Exposes service object through property", () => {
       const chart = makeChart();
       const redis = new Redis(chart, "redis-test", requiredProps);
@@ -145,6 +151,39 @@ describe("Redis", () => {
         const redis = new Redis(chart, "redis-test", requiredProps);
         expect(redis.getDnsName(replica)).toBe(expected);
       });
+    });
+  });
+
+  describe("getWaitForPortContainer", () => {
+    test("Gets a wait container for a single host", () => {
+      const chart = makeChart();
+      const redis = new Redis(chart, "redis-test", requiredProps);
+      expect(redis.getWaitForPortContainer()).toMatchInlineSnapshot(`
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "echo 'waiting for redis-test'; until nc -vz -w1 redis-test-sts-0.redis-test 6379; do sleep 1; done",
+          ],
+          "image": "busybox:1.36.1",
+          "name": "wait-for-redis-test",
+          "resources": {
+            "limits": {
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+            "requests": {
+              "cpu": Quantity {
+                "value": "10m",
+              },
+              "memory": Quantity {
+                "value": "50Mi",
+              },
+            },
+          },
+        }
+      `);
     });
   });
 });


### PR DESCRIPTION
- **feat:** add `getWaitForPortContainer` to Memcached, Mongo, Postgres, and Redis
  - add `makeWaitForPortContainer` utility function
  - add `port` property to expose the port
- **feat:** add Mongo `getWaitForReplicaSetContainer`
- **fix:** improve replica set setup
- **chore:** retryable e2e tests