### PR TITLE
feat: set replica set setup Job backoffLimit

### DIFF
--- a/lib/mongo/mongo.ts
+++ b/lib/mongo/mongo.ts
@@ -282,7 +282,7 @@ export class Mongo extends Construct implements DnsAwareStatefulSet {
     new Job(this, `${this.node.id}-setup-rs`, {
       image: `mongo:${this.release}`,
       restartPolicy: PodSpecRestartPolicy.NEVER,
-      backoffLimit: 0,
+      backoffLimit: 6,
       release: this.release,
       command: ["/bin/bash"],
       args: [


### PR DESCRIPTION
During `rs.initiate` MongoDB will try to resolve each member's IP by calling `getaddrinfo` - despite the fact that it connects to the node, resolving address might still fail, e.g.:

```
Waiting for mongo-sts-0.mongo.tarl-replset.svc.cluster.local
{ "ok" : 1 }
Initiating replica set tarl-rs0...
2024-08-19T11:35:55.446+0000 I NETWORK  [thread1] getaddrinfo("mongo-sts-0.mongo.tarl-replset.svc.cluster.local") failed: Name or service not known
2024-08-19T11:35:55.446+0000 E QUERY    [thread1] Error: couldn't initialize connection to host mongo-sts-0.mongo.tarl-replset.svc.cluster.local, address is invalid :
```

The only way around it is to retry the job.